### PR TITLE
[#14] 헤더 구현

### DIFF
--- a/src/components/base/ServiceBox.tsx
+++ b/src/components/base/ServiceBox.tsx
@@ -7,37 +7,47 @@ interface Props {
 
 const ServiceBox = ({ icon, name }: Props) => {
   return (
-    <div className={container}>
+    <button className={container}>
       <div className={circle}>{icon()}</div>
-      <span className={serviceName}>{name}</span>
-    </div>
+      {name !== '없음' ? (
+        <span className={serviceName}>{name}</span>
+      ) : (
+        <span className={noServiceName} />
+      )}
+    </button>
   );
 };
 
 export default ServiceBox;
 
 const container = css({
-  width: '6.4rem',
+  width: '6.13rem',
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
-  gap: '0.7rem',
+  gap: '0.4rem',
   position: 'relative',
+  cursor: 'pointer',
 });
 
 const circle = css({
   width: '11.3rem',
-  height: '11.4rem',
+  height: '11rem',
   background: `url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png) no-repeat 3px -252px`,
-  zoom: '0.53',
-  marginTop: '-0.2rem',
+  zoom: 0.5,
+  marginTop: '-0.7rem',
   marginLeft: '-0.3rem',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
+  paddingTop: '1.1rem',
 });
 
 const serviceName = css({
   textAlign: 'center',
-  fontSize: '1.4rem',
+  fontSize: '1.45rem',
+});
+
+const noServiceName = css({
+  marginTop: '2.2rem',
 });

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import { css } from '../../../styled-system/css';
+import { services } from '../../constants/services';
+import ServiceBox from '../base/ServiceBox';
 
 const Header = () => {
   const [isFocused, setIsFocused] = useState<boolean>(false);
@@ -40,7 +42,11 @@ const Header = () => {
             <div className={searchIcon} />
           </div>
         </div>
-        <div className={serviceList}>service-list</div>
+        <div className={serviceList}>
+          {Object.keys(services).map((key) => (
+            <ServiceBox icon={() => <div style={{ ...services[key] }} />} name={key} />
+          ))}
+        </div>
       </div>
     </header>
   );
@@ -219,8 +225,9 @@ const searchIcon = css({
 });
 
 const serviceList = css({
-  marginTop: '1.2rem',
+  marginTop: '1.1rem',
   display: 'flex',
+  flexDirection: 'row',
   alignItems: 'center',
   justifyContent: 'center',
 });

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,10 +1,47 @@
+import { useState } from 'react';
 import { css } from '../../../styled-system/css';
 
 const Header = () => {
+  const [isFocused, setIsFocused] = useState<boolean>(false);
+  isFocused;
+
   return (
     <header className={header}>
-      <div className={top}>header-top</div>
-      <div className={searchBox}>header-search</div>
+      <div className={top}>
+        <div className={items}>
+          <button className={menu} />
+          <button className={naverPay} />
+        </div>
+        <div className={items}>
+          <button className={talk} />
+          <div className={noticeBox}>
+            <button className={notice} />
+          </div>
+        </div>
+      </div>
+      <div className={searchBox}>
+        <div className={inputbox}>
+          <div className={naverWrapper}>
+            <div className={naverIcon} />
+          </div>
+          <input
+            className={input}
+            placeholder={isFocused ? '검색어를 입력해 주세요.' : ''}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
+          />
+          <button className={keyboardButton}>
+            <div className={keyboard} />
+          </button>
+          <button className={moreInfoButton}>
+            <div className={moreInfo} />
+          </button>
+          <div className={searchWrapper}>
+            <div className={searchIcon} />
+          </div>
+        </div>
+        <div className={serviceList}>service-list</div>
+      </div>
     </header>
   );
 };
@@ -17,9 +54,173 @@ const header = css({
 });
 
 const top = css({
-  height: '7.1rem',
+  position: 'relative',
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  paddingTop: '1.28rem',
+});
+
+const items = css({
+  display: 'flex',
+  gap: '2.43rem',
+  flexDirection: 'row',
+  alignItems: 'center',
+});
+
+const menu = css({
+  width: '5rem',
+  height: '4rem',
+  background: `url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -1px -672px`,
+  zoom: '0.5',
+  cursor: 'pointer',
+});
+
+const naverPay = css({
+  width: '6.4rem',
+  height: '6.4rem',
+  background: `url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -590px -354px`,
+  zoom: '0.5',
+  cursor: 'pointer',
+});
+
+const talk = css({
+  width: '5rem',
+  height: '5.2rem',
+  background: `url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -217px -666px`,
+  zoom: '0.5',
+  cursor: 'pointer',
+});
+
+const noticeBox = css({
+  marginRight: '0.38rem',
+  position: 'relative',
+  display: 'flex',
+});
+
+const notice = css({
+  width: '5.2rem',
+  height: '5rem',
+  background: `url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -108px -667px`,
+  zoom: '0.5',
+  cursor: 'pointer',
 });
 
 const searchBox = css({
+  marginTop: '1.2rem',
   height: '15.6rem',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+});
+
+const inputbox = css({
+  width: '70.8rem',
+  height: '6rem',
+  borderRadius: '3.3rem',
+  border: '0.1rem solid #03C75A',
+  overflow: 'hidden',
+  marginTop: '0.1rem',
+  display: 'flex',
+  flexDirection: 'row',
+  '&:hover': {
+    boxShadow: '0 4px 8px 0 rgba(0,0,0,0.13)',
+  },
+});
+
+const input = css({
+  width: '48rem',
+  height: '6rem',
+  backgroundColor: 'white',
+  boxSizing: 'border-box',
+  fontSize: '2.1rem',
+  fontWeight: '800',
+  color: '#101010',
+  letterSpacing: '-0.06rem',
+  outline: 'none',
+  display: 'flex',
+  flexDirection: 'row',
+  marginRight: '4.5rem',
+  '&::placeholder': {
+    color: '#F2F2F2',
+    fontWeight: '600',
+  },
+});
+
+const naverWrapper = css({
+  width: '6.7rem',
+  height: '5.8rem',
+  zIndex: 2,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  paddingLeft: '1.1rem',
+  cursor: 'pointer',
+});
+
+const naverIcon = css({
+  width: '4.8rem',
+  height: '4.8rem',
+  background: `url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -50px -720px`,
+  zoom: '0.5',
+});
+
+const keyboardButton = css({
+  width: '3rem',
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  justifyContent: 'center',
+  cursor: 'pointer',
+});
+
+const keyboard = css({
+  width: '4.8rem',
+  height: '2.8rem',
+  background: `url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png) no-repeat -398px -508px`,
+  zoom: '0.5',
+});
+
+const moreInfoButton = css({
+  width: '2.0rem',
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  justifyContent: 'center',
+  margin: '0 0.3rem',
+  paddingLeft: '0.3rem',
+  cursor: 'pointer',
+});
+
+const moreInfo = css({
+  width: '1.8rem',
+  height: '1rem',
+  background: `url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png) no-repeat -205px -545px`,
+  zoom: '0.5',
+});
+
+const searchWrapper = css({
+  width: '6.2rem',
+  height: '5.8rem',
+  zIndex: 2,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  paddingRight: '1.65rem',
+  cursor: 'pointer',
+});
+
+const searchIcon = css({
+  width: '4.9rem',
+  height: '4.8rem',
+  background: `url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png) no-repeat -729px -372px`,
+  zoom: '0.5',
+});
+
+const serviceList = css({
+  marginTop: '1.2rem',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
 });

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -14,7 +14,7 @@ const Layout = () => {
 export default Layout;
 
 const container = css({
-  maxWidth: '134rem',
+  width: '134rem',
   height: '100vh',
   margin: '0 auto',
 });

--- a/src/constants/services.ts
+++ b/src/constants/services.ts
@@ -1,0 +1,85 @@
+interface ServiceStyle {
+  [key: string]: {
+    width: string;
+    height: string;
+    background: string;
+    zoom?: number;
+    transform?: string;
+    marginBottom?: string;
+    marginLeft?: string;
+  };
+}
+
+export const services: ServiceStyle = {
+  메일: {
+    width: '6.7rem',
+    height: '7rem',
+    background:
+      'url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -508px -191px',
+  },
+  카페: {
+    width: '6.5rem',
+    height: '7rem',
+    background:
+      'url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -511px -11px',
+  },
+  블로그: {
+    width: '7.4rem',
+    height: '6.5rem',
+    background:
+      'url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -409px -211px',
+  },
+  쇼핑: {
+    width: '6.8rem',
+    height: '6.8rem',
+    background:
+      'url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -188px -431px',
+  },
+  뉴스: {
+    width: '6.8rem',
+    height: '6.2rem',
+    background:
+      'url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -8px -434px',
+  },
+  증권: {
+    width: '7.1rem',
+    height: '5.9rem',
+    background:
+      'url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -367px -436px',
+    zoom: 1,
+  },
+  부동산: {
+    width: '6.8rem',
+    height: '7.5rem',
+    background:
+      'url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -99px -428px',
+  },
+  지도: {
+    width: '9.3rem',
+    height: '8rem',
+    background:
+      'url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -413px -11px',
+    marginLeft: '1.9rem',
+  },
+  웹툰: {
+    width: '6.8rem',
+    height: '6.8rem',
+    background:
+      'url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -458px -431px',
+  },
+  치지직: {
+    width: '8.5rem',
+    height: '9.5rem',
+    background:
+      'url(https://s.pstatic.net/static/www/mobile/edit/20240112_1095/upload_1705057885416AaxUM.png)',
+    // zoom: 0.9,
+  },
+  없음: {
+    width: '3.7rem',
+    height: '3.4rem',
+    background:
+      'url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png) no-repeat -641px -156px',
+    transform: 'rotate(90deg)',
+    zoom: 1.2,
+  },
+};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -27,6 +27,7 @@ const main = css({
   display: 'flex',
   gap: '3rem',
   marginBottom: '6rem',
+  marginTop: '4.3rem',
 });
 
 const sectionLeft = css({


### PR DESCRIPTION
## 작업 내용
- 최상단 헤더 (드롭다운 메뉴, 페이, 톡, 알림)
- 검색 인풋
- 서비스 목록
페이지 이동이나 변경되는 컴포넌트는 아직 작업하지 않음.

<img width="2352" alt="스크린샷 2024-02-08 오후 10 20 04" src="https://github.com/chaeyun-sim/Naver-Clone/assets/111689342/338183a4-c251-4258-9708-eb6a9aa844d2">

<br />

Close #14 