### PR TITLE
[#21] 브라우저에 따른 스프라이트 이미지 크기 상이 수정

### DIFF
--- a/src/components/NewsSection/DefaultNewsCard.tsx
+++ b/src/components/NewsSection/DefaultNewsCard.tsx
@@ -127,10 +127,12 @@ const playBox = css({
 });
 
 const playIcon = css({
-  width: '1.4rem',
-  height: '1.8rem',
-  background: `url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png) no-repeat -148px -811px`,
-  zoom: '0.5',
+  width: '0.7rem',
+  height: '1.0rem',
+  background: `url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)`,
+  backgroundSize: '444px 434px',
+  backgroundPosition: '-327px -254px',
+  backgroundRepeat: 'no-repeat',
 });
 
 const playTime = css({

--- a/src/components/NewsSection/MediaCard.tsx
+++ b/src/components/NewsSection/MediaCard.tsx
@@ -164,8 +164,10 @@ const subtitle = css({
 });
 
 const plusIcon = css({
-  width: '1.4rem',
-  height: '1.4rem',
-  background: `url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png) no-repeat -649px -473px`,
-  zoom: '0.5',
+  width: '1rem',
+  height: '0.8rem',
+  background: `url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)`,
+  backgroundSize: '444px 434px',
+  backgroundPosition: '-323px -236px',
+  backgroundRepeat: 'no-repeat',
 });

--- a/src/components/ShoppingSection/LiveShoppingCard.tsx
+++ b/src/components/ShoppingSection/LiveShoppingCard.tsx
@@ -112,8 +112,9 @@ const noticeCircle = css({
 });
 
 const noticeIcon = css({
-  width: '2.8rem',
-  height: '2.7rem',
-  background: `url(https://spastatic.naver.com/v1/shopad/static/shopad-square-node/v2402021651/_next/static/media/sp_main.05384be4.png) no-repeat -262px -75px`,
-  zoom: '0.5',
+  width: '1.4rem',
+  height: '1.4rem',
+  background: `url(https://spastatic.naver.com/v1/shopad/static/shopad-square-node/v2402021651/_next/static/media/sp_main.05384be4.png)`,
+  backgroundSize: '159px 137px',
+  backgroundRepeat: 'no-repeat',
 });

--- a/src/components/ShoppingSection/NaverShopping.tsx
+++ b/src/components/ShoppingSection/NaverShopping.tsx
@@ -85,31 +85,39 @@ const name = css({
 });
 
 const shopIcon = css({
-  width: '3.3rem',
-  height: '3.6rem',
-  background: `url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -606px -106px`,
-  zoom: '0.5',
+  width: '3.2rem',
+  height: '3.2rem',
+  background: `url(https://spastatic.naver.com/v1/shopad/static/shopad-square-node/v2402021651/_next/static/media/sp_main.05384be4.png)`,
+  backgroundSize: '159px 137px',
+  backgroundRepeat: 'no-repeat',
+  transform: 'translate(-50%, -50%)',
 });
 
 const pointIcon = css({
-  width: '3.1rem',
-  height: '3.4rem',
-  background: `url(https://spastatic.naver.com/v1/shopad/static/shopad-square-node/v2402021651/_next/static/media/sp_main.05384be4.png) no-repeat -153px -83px`,
-  zoom: '0.5',
+  width: '3.2rem',
+  height: '3.2rem',
+  background: `url(https://spastatic.naver.com/v1/shopad/static/shopad-square-node/v2402021651/_next/static/media/sp_main.05384be4.png)`,
+  backgroundSize: '159px 137px',
+  backgroundRepeat: 'no-repeat',
+  transform: 'translate(-50%, -50%)',
 });
 
 const truckIcon = css({
-  width: '3.4rem',
-  height: '2.7rem',
-  background: `url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -606px -176px`,
-  zoom: '0.5',
+  width: '3.2rem',
+  height: '3.2rem',
+  background: `url(https://spastatic.naver.com/v1/shopad/static/shopad-square-node/v2402021651/_next/static/media/sp_main.05384be4.png)`,
+  backgroundSize: '159px 137px',
+  backgroundRepeat: 'no-repeat',
+  transform: 'translate(-50%, -50%)',
 });
 
 const bagIcon = css({
-  width: '3.3rem',
+  width: '3.2rem',
   height: '3.2rem',
-  background: `url(https://spastatic.naver.com/v1/shopad/static/shopad-square-node/v2402021651/_next/static/media/sp_main.05384be4.png) no-repeat -39px -242px`,
-  zoom: '0.5',
+  background: `url(https://spastatic.naver.com/v1/shopad/static/shopad-square-node/v2402021651/_next/static/media/sp_main.05384be4.png)`,
+  backgroundSize: '159px 137px',
+  backgroundRepeat: 'no-repeat',
+  transform: 'translate(-50%, -50%)',
 });
 
 const badge = css({

--- a/src/components/base/MenuWidget.tsx
+++ b/src/components/base/MenuWidget.tsx
@@ -67,13 +67,15 @@ const container = css({
 
 const triangleIcon = css({
   position: 'absolute',
-  top: '18.0rem',
-  left: '20.8rem',
+  top: '9.0rem',
+  left: '10.4rem',
   zIndex: 2,
-  width: '3.8rem',
-  height: '2.2rem',
-  background: `url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png) no-repeat -614px -508px`,
-  zoom: '0.5',
+  width: '1.9rem',
+  height: '1.1rem',
+  background: `url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)`,
+  backgroundSize: '444px 434px',
+  backgroundPosition: '-307px -254px',
+  backgroundRepeat: 'no-repeat',
 });
 
 const seeMoreText = css({

--- a/src/components/base/PageButton.tsx
+++ b/src/components/base/PageButton.tsx
@@ -80,18 +80,24 @@ const circle = css({
 });
 
 const leftIcon = css({
-  width: '1.5em',
-  height: '2.2rem',
-  background: `url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -391px -809px`,
+  width: '1.0em',
+  height: '1.2rem',
+  background: `url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)`,
+  backgroundPosition: '-432px -246px',
+  backgroundSize: '444px 434px',
+  backgroundRepeat: 'no-repeat',
   transform: 'rotate(180deg)',
-  zoom: '0.5',
+  marginRight: '0.7rem',
 });
 
 const rightIcon = css({
-  width: '1.5em',
-  height: '2.2rem',
-  background: `url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -391px -809px`,
-  zoom: '0.5',
+  width: '1.0em',
+  height: '1.2rem',
+  background: `url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)`,
+  backgroundPosition: '-432px -246px',
+  backgroundSize: '444px 434px',
+  backgroundRepeat: 'no-repeat',
+  marginLeft: '0.7rem',
 });
 
 const textBox = css({

--- a/src/components/base/ServiceBox.tsx
+++ b/src/components/base/ServiceBox.tsx
@@ -9,6 +9,7 @@ const ServiceBox = ({ icon, name }: Props) => {
   return (
     <button className={container}>
       <div className={circle}>{icon()}</div>
+      {/* {icon()} */}
       {name !== '없음' ? (
         <span className={serviceName}>{name}</span>
       ) : (
@@ -31,16 +32,15 @@ const container = css({
 });
 
 const circle = css({
-  width: '11.3rem',
-  height: '11rem',
-  background: `url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png) no-repeat 3px -252px`,
-  zoom: 0.5,
-  marginTop: '-0.7rem',
-  marginLeft: '-0.3rem',
+  width: '5.4rem',
+  height: '5.4rem',
+  background: `url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)`,
+  backgroundSize: '444px 434px',
+  backgroundPosition: '0px -128px',
+  backgroundRepeat: 'no-repeat',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  paddingTop: '1.1rem',
 });
 
 const serviceName = css({

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -76,26 +76,30 @@ const items = css({
 });
 
 const menu = css({
-  width: '5rem',
-  height: '4rem',
-  background: `url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -1px -672px`,
-  zoom: '0.5',
+  width: '2.6rem',
+  height: '2.6rem',
+  background: `url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)`,
+  backgroundPosition: '-314px -330px',
+  backgroundSize: '444px 434px',
   cursor: 'pointer',
 });
 
 const naverPay = css({
-  width: '6.4rem',
-  height: '6.4rem',
-  background: `url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -590px -354px`,
-  zoom: '0.5',
+  width: '3.2rem',
+  height: '3.2rem',
+  background: `url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)`,
+  backgroundSize: '444px 434px',
+  backgroundPosition: '-295px -177px',
+  backgroundRepeat: 'no-repeat',
   cursor: 'pointer',
 });
 
 const talk = css({
-  width: '5rem',
-  height: '5.2rem',
-  background: `url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -217px -666px`,
-  zoom: '0.5',
+  width: '2.6rem',
+  height: '2.6rem',
+  background: `url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)`,
+  backgroundSize: '444px 434px',
+  backgroundPosition: '-364px -81px',
   cursor: 'pointer',
 });
 
@@ -106,10 +110,11 @@ const noticeBox = css({
 });
 
 const notice = css({
-  width: '5.2rem',
-  height: '5rem',
-  background: `url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -108px -667px`,
-  zoom: '0.5',
+  width: '2.6rem',
+  height: '2.6rem',
+  background: `url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)`,
+  backgroundSize: '444px 434px',
+  backgroundPosition: '-364px -27px',
   cursor: 'pointer',
 });
 
@@ -166,10 +171,12 @@ const naverWrapper = css({
 });
 
 const naverIcon = css({
-  width: '4.8rem',
-  height: '4.8rem',
-  background: `url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -50px -720px`,
-  zoom: '0.5',
+  width: '2.6rem',
+  height: '2.6rem',
+  background: `url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)`,
+  backgroundSize: '444px 434px',
+  backgroundPosition: '-835px -1px',
+  marginTop: '0.5rem',
 });
 
 const keyboardButton = css({
@@ -182,10 +189,12 @@ const keyboardButton = css({
 });
 
 const keyboard = css({
-  width: '4.8rem',
-  height: '2.8rem',
-  background: `url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png) no-repeat -398px -508px`,
-  zoom: '0.5',
+  width: '2.4rem',
+  height: '1.4rem',
+  background: `url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)`,
+  backgroundSize: '444px 434px',
+  backgroundPosition: '-199px -254px',
+  backgroundRepeat: 'no-repeat',
 });
 
 const moreInfoButton = css({
@@ -200,10 +209,12 @@ const moreInfoButton = css({
 });
 
 const moreInfo = css({
-  width: '1.8rem',
-  height: '1rem',
-  background: `url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png) no-repeat -205px -545px`,
-  zoom: '0.5',
+  width: '1rem',
+  height: '0.6rem',
+  background: `url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)`,
+  backgroundSize: '444px 434px',
+  backgroundPosition: '-102px -272px',
+  backgroundRepeat: 'no-repeat',
 });
 
 const searchWrapper = css({
@@ -218,10 +229,11 @@ const searchWrapper = css({
 });
 
 const searchIcon = css({
-  width: '4.9rem',
-  height: '4.8rem',
-  background: `url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png) no-repeat -729px -372px`,
-  zoom: '0.5',
+  width: '2.8rem',
+  height: '2.6rem',
+  background: `url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)`,
+  backgroundSize: '444px 434px',
+  backgroundPosition: '-805px -185px',
 });
 
 const serviceList = css({

--- a/src/constants/services.ts
+++ b/src/constants/services.ts
@@ -3,6 +3,9 @@ interface ServiceStyle {
     width: string;
     height: string;
     background: string;
+    backgroundSize: string;
+    backgroundPosition: string;
+    backgroundRepeat?: string;
     zoom?: number;
     transform?: string;
     marginBottom?: string;
@@ -12,74 +15,92 @@ interface ServiceStyle {
 
 export const services: ServiceStyle = {
   메일: {
-    width: '6.7rem',
-    height: '7rem',
-    background:
-      'url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -508px -191px',
+    width: '4.4rem',
+    height: '4.4rem',
+    background: 'url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)',
+    backgroundSize: '444px 434px',
+    backgroundPosition: '-250px -90px',
+    backgroundRepeat: 'no-repeat',
   },
   카페: {
-    width: '6.5rem',
-    height: '7rem',
-    background:
-      'url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -511px -11px',
+    width: '4.4rem',
+    height: '4.4rem',
+    background: 'url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)',
+    backgroundSize: '444px 434px',
+    backgroundPosition: '-250px 0px',
+    backgroundRepeat: 'no-repeat',
   },
   블로그: {
-    width: '7.4rem',
-    height: '6.5rem',
-    background:
-      'url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -409px -211px',
+    width: '4.4rem',
+    height: '4.4rem',
+    background: 'url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)',
+    backgroundSize: '444px 434px',
+    backgroundPosition: '-201px -98px',
+    backgroundRepeat: 'no-repeat',
   },
   쇼핑: {
-    width: '6.8rem',
-    height: '6.8rem',
-    background:
-      'url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -188px -431px',
+    width: '4.4rem',
+    height: '4.4rem',
+    background: 'url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)',
+    backgroundSize: '444px 434px',
+    backgroundRepeat: 'no-repeat',
+    backgroundPosition: '-90px -209px',
   },
   뉴스: {
-    width: '6.8rem',
-    height: '6.2rem',
-    background:
-      'url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -8px -434px',
+    width: '4.4rem',
+    height: '4.4rem',
+    background: 'url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)',
+    backgroundSize: '444px 434px',
+    backgroundRepeat: 'no-repeat',
+    backgroundPosition: '0px -209px',
   },
   증권: {
-    width: '7.1rem',
-    height: '5.9rem',
-    background:
-      'url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -367px -436px',
-    zoom: 1,
+    width: '4.4rem',
+    height: '4.4rem',
+    background: 'url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)',
+    backgroundSize: '444px 434px',
+    backgroundRepeat: 'no-repeat',
+    backgroundPosition: '-180px -209px',
   },
   부동산: {
-    width: '6.8rem',
-    height: '7.5rem',
-    background:
-      'url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -99px -428px',
+    width: '4.4rem',
+    height: '4.4rem',
+    background: 'url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)',
+    backgroundSize: '444px 434px',
+    backgroundRepeat: 'no-repeat',
+    backgroundPosition: '-45px -209px',
   },
   지도: {
-    width: '9.3rem',
-    height: '8rem',
-    background:
-      'url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -413px -11px',
-    marginLeft: '1.9rem',
+    width: '4.4rem',
+    height: '4.4rem',
+    background: 'url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)',
+    backgroundSize: '444px 434px',
+    backgroundRepeat: 'no-repeat',
+    backgroundPosition: '-201px 0px',
   },
   웹툰: {
-    width: '6.8rem',
-    height: '6.8rem',
-    background:
-      'url(https://pm.pstatic.net/resources/asset/sp_main.2b26eb67.png) no-repeat -458px -431px',
+    width: '4.4rem',
+    height: '4.4rem',
+    background: 'url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)',
+    backgroundSize: '444px 434px',
+    backgroundRepeat: 'no-repeat',
+    backgroundPosition: '-225px -209px',
   },
   치지직: {
-    width: '8.5rem',
-    height: '9.5rem',
+    width: '4.4rem',
+    height: '4.4rem',
     background:
       'url(https://s.pstatic.net/static/www/mobile/edit/20240112_1095/upload_1705057885416AaxUM.png)',
-    // zoom: 0.9,
+    backgroundRepeat: 'no-repeat',
+    backgroundSize: 'cover',
+    backgroundPosition: '',
   },
   없음: {
-    width: '3.7rem',
-    height: '3.4rem',
-    background:
-      'url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png) no-repeat -641px -156px',
-    transform: 'rotate(90deg)',
-    zoom: 1.2,
+    width: '4.4rem',
+    height: '4.4rem',
+    background: 'url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)',
+    backgroundSize: '444px 434px',
+    backgroundRepeat: 'no-repeat',
+    backgroundPosition: '-520px -295px',
   },
 };


### PR DESCRIPTION
## 작업 내용
- 헤더, 뉴스섹션 등 일정하지 않은 이미지 크기 수정함.
<img width="775" alt="스크린샷 2024-02-12 오전 12 34 25 (1)" src="https://github.com/chaeyun-sim/Naver-Clone/assets/111689342/8d1c42e3-a79c-44b0-86ca-3cc1d461d7aa">
<img width="750" alt="스크린샷 2024-02-12 오전 1 59 54" src="https://github.com/chaeyun-sim/Naver-Clone/assets/111689342/75664889-1f47-40ac-9049-284c1728aaf1">

<br />

Close #21 