### PR TITLE
[#26] 쇼핑 섹션 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "axios": "^1.6.7",
     "chart.js": "^4.4.1",
     "classnames": "^2.5.1",
+    "dompurify": "^3.0.9",
     "dotenv": "^16.4.4",
     "jotai": "^2.6.3",
     "prettier": "^3.2.4",

--- a/panda.config.ts
+++ b/panda.config.ts
@@ -30,6 +30,12 @@ export default defineConfig({
           },
         },
       },
+      keyframes: {
+        fadeout: {
+          '0%': { opacity: '1' },
+          '100%': { opacity: '0' },
+        },
+      },
     },
   },
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ dependencies:
   classnames:
     specifier: ^2.5.1
     version: 2.5.1
+  dompurify:
+    specifier: ^3.0.9
+    version: 3.0.9
   dotenv:
     specifier: ^16.4.4
     version: 16.4.5
@@ -2370,6 +2373,10 @@ packages:
   /domain-browser@1.2.0:
     resolution: {integrity: sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==}
     engines: {node: '>=0.4', npm: '>=1.2'}
+    dev: false
+
+  /dompurify@3.0.9:
+    resolution: {integrity: sha512-uyb4NDIvQ3hRn6NiC+SIFaP4mJ/MdXlvtunaqK9Bn6dD3RuB/1S/gasEjDHD8eiaqdSael2vBv+hOs7Y+jhYOQ==}
     dev: false
 
   /dotenv@16.4.5:

--- a/src/api/service.ts
+++ b/src/api/service.ts
@@ -1,5 +1,10 @@
 import axios from 'axios';
-import { VITE_APP_ACCU_WEATHER_API_KEY, VITE_APP_OPEN_WEATHER_API_KEY } from '../configs';
+import {
+  VITE_APP_ACCU_WEATHER_API_KEY,
+  VITE_APP_NAVER_CLIENT_ID,
+  VITE_APP_NAVER_CLIENT_SECRET,
+  VITE_APP_OPEN_WEATHER_API_KEY,
+} from '../configs';
 
 type Name = {
   official: string;
@@ -156,5 +161,41 @@ export const getCurrentWeahter = async ({ lat, lon }: { lat: number; lon: number
     return res.data;
   } catch (error) {
     console.log(`${error}`);
+  }
+};
+
+const fetchItems = async (query: string, display: number) => {
+  const { data } = await axios.get('/v1/search/shop', {
+    params: { query, display },
+    headers: {
+      'X-Naver-Client-Id': VITE_APP_NAVER_CLIENT_ID,
+      'X-Naver-Client-Secret': VITE_APP_NAVER_CLIENT_SECRET,
+    },
+  });
+  return data.items;
+};
+
+export const getShoppingData = async ({ category }: { category: number }) => {
+  try {
+    let items = [];
+
+    if (category === 0) {
+      const queries = ['여성', '화장', '봄'];
+      const requests = queries.map((query) => fetchItems(query, 10));
+      const results = await Promise.all(requests);
+      items = results.flat();
+    } else if (category === 1) {
+      const queries = ['남성', '맨'];
+      const requests = queries.map((query) => fetchItems(query, 20));
+      const results = await Promise.all(requests);
+      items = results.flat();
+    } else if (category === 2) {
+      items = await fetchItems('원쁠딜', 100);
+    }
+
+    return items.sort(() => Math.random() - 0.5);
+  } catch (error) {
+    console.error(error);
+    return [];
   }
 };

--- a/src/components/Home/LeftSection.tsx
+++ b/src/components/Home/LeftSection.tsx
@@ -1,5 +1,6 @@
 import { css } from '../../../styled-system/css';
 import News from '../NewsSection/News';
+import Shopping from '../ShoppingSection/Shopping';
 import Section from '../base/Section';
 
 const LeftSection = () => {
@@ -17,6 +18,9 @@ const LeftSection = () => {
       </div>
       <div className={newsWrapper}>
         <News />
+      </div>
+      <div className={shoppingWrapper}>
+        <Shopping />
       </div>
     </div>
   );
@@ -43,4 +47,9 @@ const banner = css({
 const newsWrapper = css({
   marginTop: '1.6rem',
   height: '42.6rem',
+});
+
+const shoppingWrapper = css({
+  marginTop: '1.6rem',
+  height: '56rem',
 });

--- a/src/components/LeftSection/SubCategories.tsx
+++ b/src/components/LeftSection/SubCategories.tsx
@@ -1,6 +1,6 @@
 import { css } from '../../../styled-system/css';
+import { serviceUrl } from '../LeftSection/News/constants/serviceUrl';
 import Divider from '../base/Divider';
-import { serviceUrl } from './News/constants/serviceUrl';
 
 interface Props {
   currentCategory: number;

--- a/src/components/NewsSection/News.tsx
+++ b/src/components/NewsSection/News.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import Section from '../base/Section';
 import Tabs from '../base/Tabs';
 import NewsCategories from '../LeftSection/NewsCategories';
-import SubCategories from '../LeftSection/SubCategories';
 import Entertainment from '../LeftSection/News/Entertainment';
 import Sports from '../LeftSection/News/Sports';
 import Economy from '../LeftSection/News/Economy';
@@ -10,6 +9,7 @@ import PageButton from '../base/PageButton';
 import { css } from '../../../styled-system/css';
 import Media from '../LeftSection/News/Media';
 import NewsStand from '../LeftSection/News/NewsStand';
+import SubCategories from '../LeftSection/SubCategories';
 
 const categoryList = [
   {

--- a/src/components/ShoppingSection/Brand.tsx
+++ b/src/components/ShoppingSection/Brand.tsx
@@ -1,6 +1,7 @@
 import { css } from '../../../styled-system/css';
 import classNames from 'classnames';
 import { BrandItems } from './data';
+import usePriceSeperator from '../../hooks/usePriceSeperator';
 
 interface Props {
   data: BrandItems;
@@ -8,6 +9,7 @@ interface Props {
 }
 
 const Brand = ({ data, page }: Props) => {
+  const seperator = usePriceSeperator();
   const key = Object.keys(data)[page - 2];
 
   return (
@@ -58,7 +60,7 @@ const Brand = ({ data, page }: Props) => {
           <div className={blocktw}>
             <span className={outerText}>{data[key][2].name}</span>
             <div>
-              <span className={price}>{data[key][2].price}원</span>
+              <span className={price}>{seperator(data[key][2].price as number)}원</span>
             </div>
           </div>
         </a>

--- a/src/components/ShoppingSection/Brand.tsx
+++ b/src/components/ShoppingSection/Brand.tsx
@@ -1,0 +1,222 @@
+import { css } from '../../../styled-system/css';
+import classNames from 'classnames';
+import { BrandItems } from './data';
+
+interface Props {
+  data: BrandItems;
+  page: number;
+}
+
+const Brand = ({ data, page }: Props) => {
+  const key = Object.keys(data)[page - 2];
+
+  return (
+    <div className={brandshop}>
+      <div>
+        <a className={brandshopTitle}>
+          <strong className={title}>{key}</strong>
+        </a>
+      </div>
+      <div className={brandshopBox}>
+        <div>
+          <ul className={brandshopBoxList}>
+            <li className={brandshopBoxItem}>
+              <a href={data[key][0].url}>
+                <div className={block}>
+                  <span className={classNames(imageContent(), beforeImage)}>
+                    <img src={data[key][0].image} width={108} height={115} />
+                  </span>
+                  {data[key][0].discount && (
+                    <span className={discount}>{data[key][0].discount}%</span>
+                  )}
+                  <span className={text}>{data[key][0].name}</span>
+                </div>
+              </a>
+            </li>
+            <li className={brandshopBoxItem}>
+              <a href={data[key][1].url} target="_blank" rel="noreferrer">
+                <div className={block}>
+                  <span className={classNames(imageContent(), beforeImage)}>
+                    <img src={data[key][1].image} width={108} height={115} />
+                  </span>
+                  {data[key][1].discount && (
+                    <span className={discount}>{data[key][1].discount}%</span>
+                  )}
+                  <span className={text}>{data[key][1].name}</span>
+                </div>
+              </a>
+            </li>
+          </ul>
+        </div>
+        <a href={data[key][2].url} target="_blank" rel="noreferrer" className={brandshopContent}>
+          <div className={block}>
+            <span className={imageContent('22.4rem', '12.6rem')}>
+              <img src={data[key][2].image} width={224} height={126} />
+            </span>
+            <span className={discount}></span>
+          </div>
+          <div className={blocktw}>
+            <span className={outerText}>{data[key][2].name}</span>
+            <div>
+              <span className={price}>{data[key][2].price}원</span>
+            </div>
+          </div>
+        </a>
+      </div>
+    </div>
+  );
+};
+
+export default Brand;
+
+const brandshop = css({
+  overflow: 'hidden',
+  width: '24.8rem',
+  border: '1px solid rgba(0,0,0,.05)',
+  borderRadius: '0.4rem',
+  backgroundColor: '#f5f8fb',
+  boxSizing: 'border-box',
+  display: 'block',
+});
+
+const brandshopTitle = css({
+  fontSize: '1.4rem',
+  lineHeight: '1.7rem',
+  position: 'relative',
+  display: 'flex',
+  padding: '1.5rem 2.4rem 1rem 1.2rem',
+  textDecoration: 'none',
+  '&::after': {
+    content: '""',
+    backgroundImage:
+      'url(https://spastatic.naver.com/v1/shopad/static/shopad-square-node/v2402021651/_next/static/media/sp_main.05384be4.png)',
+    backgroundSize: '15.9rem 13.7rem',
+    backgroundRepeat: 'no-repeat',
+    backgroundPosition: '-14.8rem -7.6rem',
+    width: '0.8rem',
+    height: '1.2rem',
+    margin: '0.4rem 0 0 0.5rem',
+    flex: 'none',
+  },
+});
+
+const title = css({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  lineHeight: '2rem',
+  fontSize: '1.5rem',
+  fontWeight: 'bold',
+});
+
+const brandshopBox = css({
+  display: 'block',
+  padding: '0 1.1rem 1.2rem',
+});
+
+const brandshopBoxList = css({
+  display: 'flex',
+  justifyContent: 'space-between',
+  listStyle: 'none',
+});
+
+const brandshopBoxItem = css({
+  width: '10.8rem',
+  margin: 0,
+  padding: 0,
+});
+
+const block = css({
+  position: 'relative',
+});
+
+const imageContent = (width?: string, height?: string) =>
+  css({
+    width: width || '10.8rem',
+    height: height || '11.5rem',
+    overflow: 'hidden',
+    position: 'relative',
+    display: 'block',
+    borderRadius: '0.4rem',
+
+    '&::after': {
+      content: '""',
+      display: 'block',
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      border: '1px solid rgba(0,0,0,.06)',
+      borderRadius: 'inherit',
+      backgroundColor: 'rgba(0,0,0,.03)',
+      transform: 'translateZ(0)',
+      perspective: '0.1rem',
+    },
+  });
+
+const discount = css({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  width: '4rem',
+  borderRadius: '0.4rem 0 0.4rem 0',
+  fontSize: '1.1rem',
+  lineHeight: '2rem',
+  fontWeight: '700',
+  letterSpacing: '.3px',
+  textAlign: 'center',
+  color: 'white',
+  backgroundColor: 'rgba(0,0,0,.5)',
+});
+
+const text = css({
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+  position: 'absolute',
+  right: '1rem',
+  bottom: '0.6rem',
+  left: '1rem',
+  fontSize: '1.3rem',
+  lineHeight: '1.9rem',
+  fontWeight: '700',
+  letterSpacing: '-.5px',
+  color: 'white',
+});
+
+const brandshopContent = css({
+  marginTop: '1.2rem',
+  display: 'block',
+});
+
+const blocktw = css({
+  marginTop: '0.8rem',
+  fontSize: '1.3rem',
+  lineHeight: '1.9rem',
+});
+
+const price = css({
+  fontWeight: '700',
+});
+
+const beforeImage = css({
+  '&::before': {
+    content: '""',
+    display: 'block',
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    background: 'linear-gradient(180deg,rgba(0,0,0,.03) 50%,rgba(0,0,0,.3))',
+  },
+});
+
+const outerText = css({
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+  fontSize: '1.3rem',
+  lineHeight: '1.9rem',
+  fontWeight: '600',
+  color: '#101010',
+});

--- a/src/components/ShoppingSection/CategoryMens.tsx
+++ b/src/components/ShoppingSection/CategoryMens.tsx
@@ -1,0 +1,84 @@
+import { css } from '../../../styled-system/css';
+import Items from './Items';
+import MallNameGroup from './MallNameGroup';
+import NaverShopping from './NaverShopping';
+import { ShopItem } from './Shopping';
+
+interface Props {
+  page: number;
+  data: ShopItem[];
+}
+
+const CategoryMens = ({ page, data }: Props) => {
+  return (
+    <div className={commerceArea}>
+      <Items page={page} data={data} />
+      <div className={rightSection}>
+        <MallNameGroup />
+        <NaverShopping />
+        <div className={adBox}>
+          <a
+            href="https://item.gmarket.co.kr/Item?goodscode=3419482196&jaehuid=200014609&NaPm=ct%3Dlsuhuh34%7Cci%3D0e1132c32444c2421ec55c18584479ae861e9d99%7Ctr%3Dsbsf%7Csn%3D24%7Cic%3D%7Chk%3Dbf854dc033ed11745cc54b525291f07cea303fde"
+            className={adBoxImage}
+          >
+            <span className={adContentImage}>
+              <img
+                src="https://s.pstatic.net/shopping.phinf/20240216_1/6438bcdf-2a3f-4689-a431-4326814eaefd.jpg"
+                style={{ width: '100%', height: '100%' }}
+              />
+            </span>
+            <div className={adText}>갤럭시Z플립~BIG SALE특가+12%쿠폰</div>
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CategoryMens;
+
+const commerceArea = css({
+  display: 'flex',
+  height: '39.4rem',
+  padding: '1.8rem 2rem 0.1rem',
+  boxSizing: 'border-box',
+  fontSize: '1.4rem',
+  lineHeight: '1.7rem',
+  fontWeight: '500',
+});
+
+const adBox = css({
+  height: '17.3rem',
+});
+
+const adBoxImage = css({
+  display: 'block',
+  marginTop: '1.2rem',
+  textDecoration: 'none',
+});
+
+const adContentImage = css({
+  width: '24.8rem',
+  height: '14.6rem',
+  overflow: 'hidden',
+  position: 'relative',
+  display: 'block',
+  border: '0.1rem solid rgba(0,0,0,0.05)',
+  borderRadius: '0.4rem',
+});
+
+const adText = css({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  marginTop: '0.8rem',
+  fontSize: '1.3rem',
+  lineHeight: '1.9rem',
+  textAlign: 'center',
+});
+
+const rightSection = css({
+  flex: '1 1',
+  minWidth: 0,
+  display: 'block',
+});

--- a/src/components/ShoppingSection/CategoryOnePlusDeal.tsx
+++ b/src/components/ShoppingSection/CategoryOnePlusDeal.tsx
@@ -1,0 +1,193 @@
+import { useEffect, useState } from 'react';
+import { css } from '../../../styled-system/css';
+import OnePlusDealCard from './OnePlusDealCard';
+import { ShopItem } from './Shopping';
+import OnePlusDealHorizontalCard from './OnePlusDealHorizontalCard';
+import { toBeOpenedList } from './data';
+import ToBeOpenedCard from './ToBeOpenedCard';
+
+interface Filters {
+  [key: number]: (el?: ShopItem) => boolean | ShopItem[];
+}
+
+interface Props {
+  page: number;
+  data: ShopItem[];
+}
+
+const CategoryOnePlusDeal = ({ page, data }: Props) => {
+  const [dataSet, setDataSet] = useState<ShopItem[]>([]);
+
+  const filters: Filters = {
+    1: () => data,
+    2: (el) => el?.category1 === '식품',
+    3: (el) => ['출산/육아', '생활/건강'].includes(el?.category1 as string),
+    4: (el) => el?.category1 === '가구/인테리어',
+    5: (el) => el?.category1 === '디지털/가전',
+    6: (el) => ['패션의류', '화장품/미용'].includes(el?.category1 as string),
+    7: (el) => ['10', '11', '12'].includes(el?.productType as string),
+  };
+
+  useEffect(() => {
+    const filterFunction = filters[page] || (() => data);
+    if (page === 1) {
+      setDataSet(filterFunction() as ShopItem[]);
+    } else {
+      setDataSet(data.filter(filterFunction as (el: ShopItem) => boolean));
+    }
+  }, [page, data]);
+
+  const removeString = (str: string) => {
+    let result = str.split('<b>').join(' ');
+    result = result.split('</b>').join(' ');
+    return result;
+  };
+
+  return (
+    <>
+      {page < 7 ? (
+        <div className={commerceArea}>
+          <div className={threeColumn}>
+            <ul className={threeColumnList}>
+              {dataSet.slice(0, 6).map((item, index) => (
+                <li key={item.title} className={threeColumnItem(index < 3)}>
+                  <OnePlusDealCard
+                    title={removeString(item.title)}
+                    price={item.lprice}
+                    url={item.link}
+                    image={item.image}
+                  />
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className={sidearea}>
+            <div className={sideTitle}>
+              <em>만원쁠딜</em>
+              배송비 포함가격 맞아요
+            </div>
+            <ul className={sideList}>
+              {dataSet
+                .filter((el) => Number(el.lprice) < 10000)
+                .slice(0, 3)
+                .map((item) => (
+                  <li key={item.title} className={sideItem}>
+                    <OnePlusDealHorizontalCard
+                      price={Number(item.lprice)}
+                      title={removeString(item.title)}
+                      image={item.image}
+                      url={item.link}
+                    />
+                  </li>
+                ))}
+            </ul>
+          </div>
+        </div>
+      ) : (
+        <div className={commerceArea}>
+          <div className={twoColumn}>
+            <ul className={twoColumnList}>
+              {toBeOpenedList.map((item, index) => (
+                <li key={item.name} className={twoColumnItem(index < 2)}>
+                  <ToBeOpenedCard {...item} />
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default CategoryOnePlusDeal;
+
+const commerceArea = css({
+  display: 'flex',
+  height: '39.4rem',
+  padding: '1.8rem 2rem 0.1rem 0',
+  boxSizing: 'border-box',
+  fontSize: '1.4rem',
+  lineHeight: '1.7rem',
+  fontWeight: '500',
+});
+
+const threeColumn = css({
+  marginRight: '2rem',
+  width: '54rem',
+});
+
+const sidearea = css({
+  position: 'relative',
+  flex: '1 1',
+  paddingLeft: '2.1rem',
+  '&::before': {
+    content: '""',
+    display: 'block',
+    position: 'absolute',
+    top: 0,
+    bottom: '2rem',
+    left: 0,
+    backgroundColor: '#EBEBEB',
+    width: '0.1rem',
+  },
+});
+
+const threeColumnList = css({
+  width: '100%',
+  listStyle: 'none',
+  display: 'flex',
+  flexWrap: 'wrap',
+});
+
+const threeColumnItem = (isFirstLine?: boolean) =>
+  css({
+    paddingLeft: 0,
+    float: 'left',
+    height: '16.5rem',
+    marginBottom: isFirstLine ? '2.7rem' : 0,
+  });
+
+const sideTitle = css({
+  color: '#606060',
+  marginBottom: '1.2rem',
+  padding: '1rem 1.2rem',
+  borderRadius: '0.4rem',
+  backgroundColor: '#FFF3F0',
+  fontSize: '1.4rem',
+  lineHeight: '2rem',
+  whiteSpace: 'nowrap',
+  '& em': {
+    color: '#101010',
+    marginRight: '0.8rem',
+    fontWeight: '700',
+  },
+});
+
+const sideList = css({
+  listStyle: 'none',
+});
+
+const sideItem = css({
+  marginBottom: '1.2rem',
+});
+
+const twoColumn = css({
+  position: 'relative',
+  flex: '1 1',
+  display: 'block',
+});
+
+const twoColumnList = css({
+  display: 'flex',
+  flexWrap: 'wrap',
+  listStyle: 'none',
+  paddingLeft: '2rem',
+});
+
+const twoColumnItem = (isFirstLine?: boolean) =>
+  css({
+    marginTop: isFirstLine ? 0 : '1.2rem',
+    display: 'flex',
+    alignItems: 'center',
+  });

--- a/src/components/ShoppingSection/CategoryShopping.tsx
+++ b/src/components/ShoppingSection/CategoryShopping.tsx
@@ -1,0 +1,93 @@
+import { css } from '../../../styled-system/css';
+import Items from './Items';
+import MallNameGroup from './MallNameGroup';
+import NaverShopping from './NaverShopping';
+import Brand from './Brand';
+import { brandData } from './data';
+import HotMallList from './HotMallList';
+import { ShopItem } from './Shopping';
+
+interface Props {
+  page: number;
+  data: ShopItem[];
+}
+
+const CategoryShopping = ({ page, data }: Props) => {
+  return (
+    <div className={commerceArea}>
+      <Items page={page} data={data} />
+      <div className={rightSection}>
+        {page === 1 && (
+          <>
+            <MallNameGroup />
+            <NaverShopping />
+            <div className={adBox}>
+              <a
+                href="https://item.gmarket.co.kr/Item?goodscode=3419482196&jaehuid=200014609&NaPm=ct%3Dlsuhuh34%7Cci%3D0e1132c32444c2421ec55c18584479ae861e9d99%7Ctr%3Dsbsf%7Csn%3D24%7Cic%3D%7Chk%3Dbf854dc033ed11745cc54b525291f07cea303fde"
+                className={adBoxImage}
+              >
+                <span className={adContentImage}>
+                  <img
+                    src="https://s.pstatic.net/shopping.phinf/20240216_1/6438bcdf-2a3f-4689-a431-4326814eaefd.jpg"
+                    style={{ width: '100%', height: '100%' }}
+                  />
+                </span>
+                <div className={adText}>갤럭시Z플립~BIG SALE특가+12%쿠폰</div>
+              </a>
+            </div>
+          </>
+        )}
+        {[2, 3, 4].includes(page) && <Brand data={brandData} page={page} />}
+        {page === 5 && <HotMallList />}
+      </div>
+    </div>
+  );
+};
+
+export default CategoryShopping;
+
+const commerceArea = css({
+  display: 'flex',
+  height: '39.4rem',
+  padding: '1.8rem 2rem 0.1rem',
+  boxSizing: 'border-box',
+  fontSize: '1.4rem',
+  lineHeight: '1.7rem',
+  fontWeight: '500',
+});
+
+const adBox = css({
+  height: '17.3rem',
+});
+
+const adBoxImage = css({
+  display: 'block',
+  marginTop: '1.2rem',
+  textDecoration: 'none',
+});
+
+const adContentImage = css({
+  width: '24.8rem',
+  height: '14.6rem',
+  overflow: 'hidden',
+  position: 'relative',
+  display: 'block',
+  border: '0.1rem solid rgba(0,0,0,0.05)',
+  borderRadius: '0.4rem',
+});
+
+const adText = css({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  marginTop: '0.8rem',
+  fontSize: '1.3rem',
+  lineHeight: '1.9rem',
+  textAlign: 'center',
+});
+
+const rightSection = css({
+  flex: '1 1',
+  minWidth: 0,
+  display: 'block',
+});

--- a/src/components/ShoppingSection/CategoryShoppingLive.tsx
+++ b/src/components/ShoppingSection/CategoryShoppingLive.tsx
@@ -3,12 +3,14 @@ import { css } from '../../../styled-system/css';
 import LiveShoppingCard from './LiveShoppingCard';
 import { CardData, cardData } from './constant/liveShoppingData';
 import { upcomingData } from './constant/upcomingData';
+import usePriceSeperator from '../../hooks/usePriceSeperator';
 
 interface Props {
   page: number;
 }
 
 const CategoryShoppingLive = ({ page }: Props) => {
+  const seperator = usePriceSeperator();
   const [selectedCard, setSelectedCard] = useState<number>(0);
   const [liveData, setLiveData] = useState<CardData[]>([]);
 
@@ -50,7 +52,9 @@ const CategoryShoppingLive = ({ page }: Props) => {
                     <span className={productDiscount}>
                       {liveData[selectedCard]?.product?.discount}%
                     </span>
-                    <span className={productPrice}>{liveData[selectedCard].product?.price}원</span>
+                    <span className={productPrice}>
+                      {seperator(liveData[selectedCard].product?.price as number)}원
+                    </span>
                   </div>
                 </div>
               </div>

--- a/src/components/ShoppingSection/CategoryShoppingLive.tsx
+++ b/src/components/ShoppingSection/CategoryShoppingLive.tsx
@@ -1,0 +1,455 @@
+import { useEffect, useState } from 'react';
+import { css } from '../../../styled-system/css';
+import LiveShoppingCard from './LiveShoppingCard';
+import { CardData, cardData } from './constant/liveShoppingData';
+import { upcomingData } from './constant/upcomingData';
+
+interface Props {
+  page: number;
+}
+
+const CategoryShoppingLive = ({ page }: Props) => {
+  const [selectedCard, setSelectedCard] = useState<number>(0);
+  const [liveData, setLiveData] = useState<CardData[]>([]);
+
+  useEffect(() => {
+    setLiveData([...cardData].sort(() => Math.random() - 0.5));
+  }, [page]);
+
+  return (
+    <div className={container}>
+      <div className={shopLive}>
+        <div className={previewArea}>
+          <a href={liveData[selectedCard]?.url} className={thumbBox}>
+            <div className={badgeLive}>
+              <div className={liveText}>LIVE</div>
+              <span className={watchText}>{liveData[selectedCard]?.watchers} 시청</span>
+            </div>
+            <div className={thumb}>
+              <video
+                height="352"
+                autoPlay
+                width="100%"
+                className={liveVideo}
+                playsInline
+                loop
+                muted
+                poster={liveData[selectedCard]?.poster}
+                src={liveData[selectedCard]?.video}
+              ></video>
+              <i className={iconArrow} />
+            </div>
+            {liveData.length > 0 && liveData[selectedCard]?.product && (
+              <div className={product}>
+                <div className={productImageBox}>
+                  <img className={productImage} src={liveData[selectedCard]?.product?.image} />
+                </div>
+                <div className={productText}>
+                  <div className={productName}>{liveData[selectedCard]?.product?.name}</div>
+                  <div className={productData}>
+                    <span className={productDiscount}>
+                      {liveData[selectedCard]?.product?.discount}%
+                    </span>
+                    <span className={productPrice}>{liveData[selectedCard].product?.price}원</span>
+                  </div>
+                </div>
+              </div>
+            )}
+          </a>
+        </div>
+        <ul className={shopLiveList}>
+          {liveData.map((item, index) => (
+            <li key={item.text} className={shopLiveItem}>
+              <LiveShoppingCard
+                text={item.text}
+                image={item.image}
+                onClick={() => setSelectedCard(index)}
+                isSelected={selectedCard === index}
+              />
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className={schedule}>
+        <ul style={{ listStyle: 'none' }}>
+          {upcomingData.map((data, index) => (
+            <li key={data.text} className={scheduleItem(index > 0)}>
+              <a href={data.url} className={linkSchedule} />
+              <div className={scheduleBox}>
+                <div className={scheduleImageBox}>
+                  <img src={data.image} className={scheduleImage} />
+                </div>
+                <div className={scheduleInfoBox}>
+                  <div className={title}>{data.text}</div>
+                  <div className={sub}>{data.brand}</div>
+                  <div className={subBox}>
+                    <span className={time}>{data.time}</span>
+                    <button type="button" className={btnAlarm} />
+                  </div>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default CategoryShoppingLive;
+
+const container = css({
+  display: 'flex',
+  height: '39.4rem',
+  padding: '1.8rem 2rem 0.1rem',
+  boxSizing: 'border-box',
+});
+
+const shopLive = css({
+  display: 'flex',
+  width: '54rem',
+  '&::after': {
+    content: '""',
+    display: 'table',
+    tableLayout: 'fixed',
+    clear: 'both',
+  },
+});
+
+const previewArea = css({
+  width: '22.2rem',
+  paddingRight: '1.8rem',
+});
+
+const thumbBox = css({
+  position: 'relative',
+  display: 'block',
+  textDecoration: 'none',
+});
+
+const badgeLive = css({
+  position: 'absolute',
+  top: '0.8rem',
+  left: '0.8rem',
+  display: 'inline-block',
+  height: '2rem',
+  borderRadius: '1.2rem',
+  backgroundColor: 'rgba(0,0,0,.3)',
+  fontSize: '1.1rem',
+  letterSpacing: '-.4px',
+  lineHeight: '2rem',
+  verticalAlign: 'top',
+  color: 'white',
+  zIndex: 1,
+});
+
+const thumb = css({
+  backgroundImage: 'none',
+  overflow: 'hidden',
+  position: 'relative',
+  height: '30.8rem',
+  borderRadius: '0.4rem',
+  '&::before': {
+    content: '""',
+    display: 'block',
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    border: '1px solid rgba(0,0,0,.06)',
+    borderRadius: 'inherit',
+    backgroundColor: 'rgba(0,0,0,.06)',
+  },
+});
+
+const liveText = css({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  backgroundColor: '#F4361E',
+  width: '3.8rem',
+  height: '100%',
+  borderRadius: '1.2rem',
+  fontWeight: '700',
+  textAlign: 'center',
+});
+
+const watchText = css({
+  position: 'relative',
+  display: 'inline-block',
+  padding: '0 0.6rem 0 4rem',
+  verticalAlign: 'top',
+  fontSize: '1.1rem',
+  lineHeight: '2rem',
+  letterSpacing: '-.4px',
+  color: 'white',
+});
+
+const liveVideo = css({
+  width: '100%',
+  height: '100%',
+  objectFit: 'cover',
+  backgroundColor: 'transparent',
+  overflowClipMargin: 'content-box',
+  overflow: 'clip',
+});
+
+const iconArrow = css({
+  position: 'absolute',
+  right: '0.8rem',
+  bottom: '0.8rem',
+  width: '2.6rem',
+  height: '2.6rem',
+  backgroundColor: 'rgba(0,0,0,.3)',
+  borderRadius: '50%',
+  fontStyle: 'normal',
+  '&::before': {
+    content: '""',
+    display: 'block',
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    backgroundImage:
+      'url(https://spastatic.naver.com/v1/shopad/static/shopad-square-node/v2402021651/_next/static/media/sp_main.05384be4.png)',
+    backgroundSize: '15.9rem 13.7rem',
+    backgroundPosition: '-14.8rem 0',
+    backgroundRepeat: 'no-repeat',
+    width: '1.1rem',
+    height: '1rem',
+    transform: 'translate(-50%,-50%)',
+  },
+});
+
+const shopLiveList = css({
+  flex: '1 1',
+  listStyle: 'none',
+});
+
+const shopLiveItem = css({
+  display: 'inline-block',
+  width: '9rem',
+  margin: '0 1.4rem 1.4rem 0',
+  verticalAlign: 'top',
+});
+
+const product = css({
+  overflow: 'hidden',
+  display: 'flex',
+  marginTop: '1rem',
+  borderRadius: '0.4rem',
+});
+
+const productImageBox = css({
+  width: '4rem',
+  height: '4rem',
+  overflow: 'hidden',
+  position: 'relative',
+  borderRadius: '0.4rem',
+  '&::before': {
+    content: '""',
+    display: 'block',
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    border: '1px solid rgba(0,0,0,.06)',
+    borderRadius: 'inherit',
+  },
+});
+
+const productImage = css({
+  verticalAlign: 'top',
+  width: '4rem',
+  height: '4rem',
+});
+
+const productText = css({
+  overflow: 'hidden',
+  paddingLeft: '0.6rem',
+  fontSize: '1.3rem',
+  lineHeight: '2rem',
+  flex: '1 1',
+});
+
+const productName = css({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  fontSize: '1.3rem',
+  lineHeight: '2rem',
+});
+
+const productData = css({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  fontWeight: '700',
+});
+
+const productDiscount = css({
+  color: '#F4361E',
+  marginRight: '0.4rem',
+});
+
+const productPrice = css({
+  whiteSpace: 'nowrap',
+  fontWeight: '700',
+});
+
+const schedule = css({
+  overflow: 'hidden',
+  position: 'relative',
+  flex: '1 1',
+  paddingLeft: '2.1rem',
+  display: 'block',
+  cursor: 'pointer',
+  '&::before': {
+    content: '""',
+    display: 'block',
+    position: 'absolute',
+    top: 0,
+    bottom: '2rem',
+    left: 0,
+    backgroundColor: '#EBEBEB',
+    width: '0.1rem',
+  },
+});
+
+const scheduleItem = (isNotFirstLine: boolean) =>
+  css({
+    overflow: 'hidden',
+    position: 'relative',
+    borderRadius: '0.4rem',
+    marginTop: isNotFirstLine ? '1.4rem' : 0,
+    '& img': {
+      transition: 'transform 0.3s ease-in-out',
+    },
+    '&:hover img': {
+      transform: 'scale(1.1)',
+      transition: 'transform 0.3s ease-in-out',
+    },
+  });
+
+const linkSchedule = css({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  zIndex: 1,
+});
+
+const scheduleBox = css({
+  position: 'relative',
+  display: 'flex',
+  '&::after': {
+    content: '""',
+    display: 'block',
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    border: '1px solid rgba(0,0,0,.05)',
+    borderRadius: '0.4rem',
+  },
+});
+
+const scheduleImageBox = css({
+  overflow: 'hidden',
+  position: 'relative',
+  width: '8.2rem',
+  height: '11rem',
+  '&::after': {
+    content: '""',
+    display: 'block',
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    borderRight: '1px solid rgba(0,0,0,.04)',
+    backgroundColor: 'rgba(0,0,0,.03)',
+  },
+});
+
+const scheduleImage = css({
+  width: '100%',
+  height: '100%',
+});
+
+const scheduleInfoBox = css({
+  overflow: 'hidden',
+  position: 'relative',
+  flex: '1 1',
+  padding: '1.2rem 1.2rem 0 1.3rem',
+});
+
+const title = css({
+  display: 'block',
+  overflow: 'hidden',
+  maxHeight: '3.8rem',
+  lineHeight: '1.9rem',
+  textOverflow: 'ellipsis',
+  WebkitLineClamp: 2,
+  marginLeft: '0.2rem',
+  fontSize: '1.3rem',
+});
+
+const sub = css({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  color: '#606060',
+  margin: '0.2rem 0 0 0.2rem',
+  fontSize: '1.3rem',
+  lineHeight: '2rem',
+});
+
+const subBox = css({
+  position: 'absoltue',
+  right: '0.8rem',
+  bottom: '0.8rem',
+  left: '1.3rem',
+  display: 'flex',
+  justifyContent: 'space-between',
+  whiteSpace: 'nowrap',
+});
+
+const time = css({
+  color: '#404040',
+  fontSize: '1.4rem',
+  lineHeight: '2.8rem',
+  letterSpacing: '-.8px',
+});
+
+const btnAlarm = css({
+  width: '2.8rem',
+  height: '2.8rem',
+  border: '1px solid #F4361E',
+  flex: 'none',
+  position: 'relative',
+  borderRadius: '50%',
+  fontSize: '1.1rem',
+  lineHeight: '2.2rem',
+  letterSpacing: '-.26px',
+  cursor: 'pointer',
+  '&::before': {
+    content: '""',
+    backgroundImage:
+      'url(https://spastatic.naver.com/v1/shopad/static/shopad-square-node/v2402021651/_next/static/media/sp_main.05384be4.png)',
+    backgroundSize: '15.9rem 13.7rem',
+    backgroundRepeat: 'no-repeat',
+    width: '1.4rem',
+    height: '1.4rem',
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundPosition: '-13.1rem -3.8rem',
+    margin: 'auto',
+  },
+});

--- a/src/components/ShoppingSection/HotMallList.tsx
+++ b/src/components/ShoppingSection/HotMallList.tsx
@@ -1,0 +1,104 @@
+import { css } from '../../../styled-system/css';
+import { shopList } from './data';
+
+const HotMallList = () => {
+  return (
+    <div className={container}>
+      <div>
+        <a target="_blank" rel="noreferrer" className={brandshopLinkTitle}>
+          <strong className={brandshopTitleWrap}>요즘 핫한 쇼핑몰 소식</strong>
+        </a>
+      </div>
+      <div></div>
+      <div className={brandshopBlockBox}>
+        <ul className={brandshopNewsList}>
+          {shopList.map((shop, index) => (
+            <li key={shop.name} className={brandshopNewsItem(!index ? true : false)}>
+              <a href={shop.url} className={brandshopLinkNews}>
+                <div className={brandshopNewsTitle}>{shop.name}</div>
+                <div className={brandshopNewsDesc}>{shop.desc}</div>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default HotMallList;
+
+const container = css({
+  overflow: 'hidden',
+  width: '24.8rem',
+  border: '1px solid rgba(0,0,0,.05)',
+  borderRadius: '0.4rem',
+  backgroundColor: '#F5F8FB',
+  boxSizing: 'border-box',
+  display: 'block',
+});
+
+const brandshopBlockBox = css({
+  padding: '0 1.1rem 1.2rem',
+});
+
+const brandshopNewsList = css({
+  paddingBlock: '0.3rem',
+  listStyle: 'none',
+});
+
+const brandshopNewsItem = (isFirst?: boolean) =>
+  css({
+    marginTop: isFirst ? '0rem' : '1rem',
+    position: 'relative',
+    '&::before': {
+      content: '""',
+      display: 'block',
+      position: 'absolute',
+      top: '0.8rem',
+      left: 0,
+      width: '0.3rem',
+      height: '0.3rem',
+      backgroundColor: '#A881E0',
+    },
+  });
+
+const brandshopLinkTitle = css({
+  pointerEvents: 'none',
+  position: 'relative',
+  display: 'flex',
+  padding: '1.5rem 2.4rem 1rem 1.2rem',
+  textDecoration: 'none',
+});
+
+const brandshopTitleWrap = css({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  lineHeight: '2rem',
+  fontSize: '1.45rem',
+});
+
+const brandshopLinkNews = css({
+  display: 'block',
+  paddingLeft: '0.9rem',
+  lineHeight: '2rem',
+  textDecoration: 'none',
+});
+
+const brandshopNewsTitle = css({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  color: '#A881E0',
+  fontWeight: '800',
+  fontSize: '1.45rem',
+});
+
+const brandshopNewsDesc = css({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  fontWeight: '600',
+  marginTop: '0.2rem',
+});

--- a/src/components/ShoppingSection/Items.tsx
+++ b/src/components/ShoppingSection/Items.tsx
@@ -1,0 +1,141 @@
+import { css } from '../../../styled-system/css';
+import DOMPurify from 'dompurify';
+import { ShopItem } from './Shopping';
+
+interface Props {
+  page: number;
+  data: ShopItem[];
+}
+
+const Items = ({ page, data }: Props) => {
+  return (
+    <div className={leftSection}>
+      <ul className={hotList}>
+        {data.slice((page - 1) * 5, page * 5).map((item) => {
+          const title = DOMPurify.sanitize(item.title.split('<b>').join(' '));
+
+          return (
+            <li key={item.title} className={hotItem}>
+              <a href={item.link}>
+                <div className={hotItemArea}>
+                  <span className={hotItemImageBox}>
+                    <img src={item.image} className={hotItemImage} />
+                  </span>
+                  <span className={hotItemTextBox}>
+                    <div className={hotItemText}>{title}</div>
+                  </span>
+                </div>
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+      <ul className={hotList}>
+        {data.slice(page * 5, (page + 1) * 5).map((item) => {
+          const title = DOMPurify.sanitize(item.title.split('<b>').join(' '));
+
+          return (
+            <li key={item.title} className={hotItem}>
+              <a href={item.link}>
+                <div className={hotItemArea}>
+                  <span className={hotItemImageBox}>
+                    <img src={item.image} className={hotItemImage} />
+                  </span>
+                  <div className={hotItemTextBox}>
+                    <div
+                      className={hotItemText}
+                      dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(title) }}
+                    />
+                  </div>
+                </div>
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+export default Items;
+
+const leftSection = css({
+  position: 'relative',
+  width: '52.2rem',
+  marginRight: '2rem',
+});
+
+const hotList = css({
+  listStyle: 'none',
+  display: 'flex',
+  gap: '0.8rem',
+});
+
+const hotItem = css({
+  paddingBottom: '1.4rem',
+  cursor: 'pointer',
+});
+
+const hotItemArea = css({
+  position: 'relative',
+  width: '9.8rem',
+  display: 'block',
+  fontSize: '1.4rem',
+  lineHeight: ' 1.7rem',
+  '& img': {
+    transition: 'transform 0.3s ease-in-out',
+  },
+  '&:hover img': {
+    transform: 'scale(1.1)',
+    transition: 'transform 0.3s ease-in-out',
+  },
+});
+
+const hotItemImageBox = css({
+  width: '9.8rem',
+  height: '12.6rem',
+  overflow: 'hidden',
+  position: 'relative',
+  display: 'block',
+  borderRadius: '0.4rem',
+  '&::after': {
+    content: '""',
+    display: 'block',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    border: '1px solid rgba(0,0,0,.06)',
+    borderRadius: 'inherit',
+    backgroundClip: 'rgba(0,0,0,.03)',
+    transform: 'translateZ(0)',
+    perspective: '0.1rem',
+  },
+});
+
+const hotItemImage = css({
+  transition: 'transform .2s cubic-bezier(.165,.84,.44,1)',
+  imageRendering: '-webkit-optimize-contrast',
+  width: '100%',
+  height: '100%',
+  objectFit: 'cover',
+});
+
+const hotItemTextBox = css({
+  display: 'block',
+  paddingTop: '0.8rem',
+  height: '5rem',
+});
+
+const hotItemText = css({
+  overflow: 'hidden',
+  fontSize: '1.3rem',
+  lineHeight: '1.9rem',
+  letterSpacing: '-.4px',
+  whiteSpace: 'wrap',
+  WebkitLineClamp: 2,
+  height: '100%',
+  '&:hover': {
+    textDecoration: 'underline',
+  },
+});

--- a/src/components/ShoppingSection/LiveShoppingCard.tsx
+++ b/src/components/ShoppingSection/LiveShoppingCard.tsx
@@ -1,120 +1,124 @@
 import { css } from '../../../styled-system/css';
 
 interface Props {
-  title: string;
-  coverImage: string;
-  shopName: string;
-  date: string;
+  text: string;
+  image: string;
+  onClick: () => void;
+  isSelected: boolean;
 }
 
-const LiveShoppingCard = ({ title, coverImage, shopName, date }: Props) => {
-  const handleTextSlice = () => {
-    return title.length > 22 ? title.slice(0, 22) + '...' : title;
-  };
-
+const LiveShoppingCard = ({ text, image, onClick, isSelected }: Props) => {
   return (
-    <div className={container}>
-      <div className={imageWrapper}>
-        <img src={coverImage} className={image} />
-      </div>
-      <div className={box}>
-        <div className={textBox}>
-          <p className={liveTitle}>{handleTextSlice()}</p>
-          <p className={liveShopName}>{shopName}</p>
+    <div className={box} onClick={onClick}>
+      <div className={item(isSelected)}>
+        <div className={badge}>
+          <div className={badgeText}>LIVE</div>
         </div>
-        <div className={liveTimeBox}>
-          <span className={time}>{date}</span>
-          <button className={noticeCircle}>
-            <div className={noticeIcon} />
-          </button>
-        </div>
+        <span className={imgBox}>
+          <img className={img} src={image} width="90" height="126" />
+        </span>
       </div>
+      <div className={shopLiveTitle}>{text}</div>
     </div>
   );
 };
 
 export default LiveShoppingCard;
 
-const container = css({
-  borderRadius: '0.4rem',
-  display: 'flex',
-  width: '22.9rem',
-  height: '11rem',
-  overflow: 'hidden',
-  border: '0.1rem solid rgba(0,0,0,0.04)',
-});
-
-const imageWrapper = css({
-  width: '8.2rem',
-  height: '11rem',
-  overflow: 'hidden',
-  transition: 'transform 0.2s',
-  '&:hover': {
-    transform: 'scale(1.05)',
+const box = css({
+  cursor: 'pointer',
+  '& img': {
+    transition: 'transform 0.3s ease-in-out',
+  },
+  '&:hover img': {
+    transform: 'scale(1.1)',
+    transition: 'transform 0.3s ease-in-out',
   },
 });
 
-const image = css({
-  verticalAlign: 'top',
-  width: '100%',
-  height: '100%',
-  transform: 'scale(1.0)',
-  transition: 'transform 0.1s',
-});
+const item = (selected: boolean) =>
+  css({
+    position: 'relative',
+    display: 'block',
+    '&::after': {
+      content: '""',
+      display: 'block',
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      border: '1px solid #F4361E',
+      backgroundColor: 'rgba(244,54,30,.08)',
+      borderRadius: '0.4rem',
+      visibility: selected ? 'visible' : 'hidden',
+    },
+  });
 
-const box = css({
-  padding: '1.2rem 1.2rem 0 1.3rem',
-  flex: '1 1',
-  position: 'relative',
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'center',
-});
-
-const textBox = css({});
-
-const liveTitle = css({
-  fontSize: '1.3rem',
-  color: '#101010',
-  lineHeight: '1.9rem',
-  width: '10.9rem',
-  marginTop: '-0.2rem',
-});
-
-const liveShopName = css({
-  marginTop: '0.2rem',
-  color: '#606060',
-  fontSize: '1.3rem',
+const badge = css({
+  position: 'absolute',
+  top: '0.6rem',
+  left: '0.6rem',
+  display: 'inline-block',
+  height: '2rem',
+  borderRadius: '1.2rem',
+  backgroundClip: 'rgba(0,0,0,.3)',
+  fontSize: '1.1rem',
   lineHeight: '2rem',
+  letterSpacing: '-.4px',
+  verticalAlign: 'top',
+  color: 'white',
 });
 
-const liveTimeBox = css({
-  display: 'flex',
-  justifyContent: 'space-between',
-  alignItems: 'center',
-  height: '2.8rem',
+const badgeText = css({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  background: '#F4361E',
+  width: '3.8rem',
+  height: '100%',
+  borderRadius: '1.2rem',
+  fontWeight: '700',
+  textAlign: 'center',
 });
 
-const time = css({
-  fontSize: '1.3rem',
-  color: '#404040',
-});
-
-const noticeCircle = css({
-  width: '2.8rem',
-  height: '2.8rem',
-  border: '0.1rem solid #F4361E',
-  borderRadius: '50%',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
+const imgBox = css({
+  width: '9rem',
+  height: '12.6rem',
+  overflow: 'hidden',
+  position: 'relative',
+  display: 'block',
+  borderRadius: '0.4rem',
   cursor: 'pointer',
+  '&::after': {
+    content: '""',
+    display: 'block',
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    border: '1px solid rgba(0,0,0,.06)',
+    borderRadius: 'inherit',
+    background: 'rgba(0,0,0,.03)',
+    transform: 'translateZ(0)',
+    perspective: '0.1rem',
+  },
 });
 
-const noticeIcon = css({
-  width: '1.4rem',
-  height: '1.4rem',
-  background: `url(https://spastatic.naver.com/v1/shopad/static/shopad-square-node/v2402021651/_next/static/media/sp_main.05384be4.png)`,
-  backgroundSize: '159px 137px',
-  backgroundRepeat: 'no-repeat',
+const img = css({
+  transition: 'transform .2s cubic-bezier(.165,.84,.44,1)',
+  imageRendering: '-webkit-optimize-contrast',
+  pointerEvents: 'none',
+});
+
+const shopLiveTitle = css({
+  overflow: 'hidden',
+  maxHeight: '3.8rem',
+  width: '9rem',
+  lineHeight: '1.9rem',
+  textOverflow: 'ellipsis',
+  WebkitLineClamp: 2,
+  marginTop: '0.8rem',
+  fontSize: '1.3rem',
 });

--- a/src/components/ShoppingSection/MallNameGroup.tsx
+++ b/src/components/ShoppingSection/MallNameGroup.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from 'react';
 import { css } from '../../../styled-system/css';
 import Dot from '../base/Dot';
 
@@ -10,11 +11,11 @@ const MallNameGroup = () => {
 
   return (
     <div className={conatiner}>
-      {malls.map((data) => {
+      {malls.map((data, idx) => {
         return (
-          <div className={box}>
+          <div className={box} key={idx}>
             {data.map((item, index) => (
-              <>
+              <Fragment key={index}>
                 <div className={row}>
                   {['11번가', 'SSG닷컴', 'GS SHOP'].includes(item) ? (
                     <strong className={name}>{item}</strong>
@@ -22,8 +23,12 @@ const MallNameGroup = () => {
                     <span className={name}>{item}</span>
                   )}
                 </div>
-                {index < data.length - 1 && <Dot />}
-              </>
+                {index < data.length - 1 && (
+                  <div style={{ marginBottom: '0.5rem' }}>
+                    <Dot />
+                  </div>
+                )}
+              </Fragment>
             ))}
           </div>
         );

--- a/src/components/ShoppingSection/NaverShopping.tsx
+++ b/src/components/ShoppingSection/NaverShopping.tsx
@@ -1,37 +1,40 @@
+import classNames from 'classnames';
 import { css } from '../../../styled-system/css';
 
-const NaverShopping = () => {
-  const data = [
-    {
-      name: '쇼핑홈',
-      icon: shopIcon,
-    },
-    {
-      name: '리뷰적립',
-      icon: pointIcon,
-    },
-    {
-      name: '주문',
-      icon: truckIcon,
-    },
-    {
-      name: '장바구니',
-      icon: bagIcon,
-    },
-  ];
+const data = [
+  {
+    name: '쇼핑홈',
+    position: '-3.4rem 0',
+    url: 'https://shopping.naver.com/home',
+  },
+  {
+    name: '리뷰적립',
+    position: '-6.8rem -3.4rem',
+    url: 'https://shopping.naver.com/my/writable-reviews',
+  },
+  {
+    name: '주문',
+    position: '-3.4rem -3.4rem',
+    url: 'https://new-m.pay.naver.com/pcpay?serviceGroup=SHOPPING&page=1',
+  },
+  {
+    name: '장바구니',
+    position: '',
+    url: 'https://shopping.naver.com/cart',
+  },
+];
 
+const NaverShopping = () => {
   return (
     <div className={container}>
       {data.map((box) => (
-        <div key={box.name} className={item}>
-          <div className={box.name === '리뷰적립' ? itemWithBadge : ''}>
+        <a href={box.url} key={box.name} className={item}>
+          <div className={itemWithBadge}>
             {box.name === '리뷰적립' && <span className={badge}>5</span>}
-            <div className={iconCircle}>
-              <div className={box.icon} />
-            </div>
+            <div className={classNames(iconCircle, icon(box.name, box.position))} />
           </div>
           <span className={name}>{box.name}</span>
-        </div>
+        </a>
       ))}
     </div>
   );
@@ -45,11 +48,12 @@ const itemWithBadge = css({
   flexDirection: 'row',
   alignItems: 'center',
   justifyContent: 'center',
+  cursor: 'pointer',
 });
 
 const container = css({
   width: '24.8rem',
-  height: '6.5rem',
+  height: '7.2rem',
   padding: '0.9rem',
   marginTop: '1.2rem',
   borderRadius: '0.4rem',
@@ -82,43 +86,28 @@ const name = css({
   color: '#404040',
   fontSize: '1.3rem',
   fontWeight: '500',
+  marginTop: '0.3rem',
 });
 
-const shopIcon = css({
-  width: '3.2rem',
-  height: '3.2rem',
-  background: `url(https://spastatic.naver.com/v1/shopad/static/shopad-square-node/v2402021651/_next/static/media/sp_main.05384be4.png)`,
-  backgroundSize: '159px 137px',
-  backgroundRepeat: 'no-repeat',
-  transform: 'translate(-50%, -50%)',
-});
+// icon
 
-const pointIcon = css({
-  width: '3.2rem',
-  height: '3.2rem',
-  background: `url(https://spastatic.naver.com/v1/shopad/static/shopad-square-node/v2402021651/_next/static/media/sp_main.05384be4.png)`,
-  backgroundSize: '159px 137px',
-  backgroundRepeat: 'no-repeat',
-  transform: 'translate(-50%, -50%)',
-});
-
-const truckIcon = css({
-  width: '3.2rem',
-  height: '3.2rem',
-  background: `url(https://spastatic.naver.com/v1/shopad/static/shopad-square-node/v2402021651/_next/static/media/sp_main.05384be4.png)`,
-  backgroundSize: '159px 137px',
-  backgroundRepeat: 'no-repeat',
-  transform: 'translate(-50%, -50%)',
-});
-
-const bagIcon = css({
-  width: '3.2rem',
-  height: '3.2rem',
-  background: `url(https://spastatic.naver.com/v1/shopad/static/shopad-square-node/v2402021651/_next/static/media/sp_main.05384be4.png)`,
-  backgroundSize: '159px 137px',
-  backgroundRepeat: 'no-repeat',
-  transform: 'translate(-50%, -50%)',
-});
+const icon = (name: string, position: string) =>
+  css({
+    '&::before': {
+      content: '""',
+      display: 'block',
+      width: name === '장바구니' ? '1.7rem' : '3.2rem',
+      height: name === '장바구니' ? '1.6rem' : '3.2rem',
+      backgroundImage: `url(https://spastatic.naver.com/v1/shopad/static/shopad-square-node/v2402021651/_next/static/media/sp_main.05384be4.png)`,
+      backgroundPosition: name === '장바구니' ? '-1.9rem -12.1rem' : position,
+      backgroundSize: '15.9rem 13.7rem',
+      backgroundRepeat: 'no-repeat',
+      transform: 'translate(-50%,-50%)',
+      position: 'absolute',
+      top: '50%',
+      left: '50%',
+    },
+  });
 
 const badge = css({
   position: 'absolute',

--- a/src/components/ShoppingSection/OnePlusDealCard.tsx
+++ b/src/components/ShoppingSection/OnePlusDealCard.tsx
@@ -1,4 +1,5 @@
 import { css } from '../../../styled-system/css';
+import usePriceSeperator from '../../hooks/usePriceSeperator';
 
 interface Props {
   price: string;
@@ -8,9 +9,7 @@ interface Props {
 }
 
 const OnePlusDealCard = ({ image, title, url, price }: Props) => {
-  const handleSeperator = () => {
-    return String(price).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-  };
+  const seperator = usePriceSeperator();
 
   return (
     <a href={url}>
@@ -28,7 +27,7 @@ const OnePlusDealCard = ({ image, title, url, price }: Props) => {
           <img src={image} className={image} />
         </div>
         <div className={textBox}>
-          <span className={priceStyle}>{handleSeperator()}원</span>
+          <span className={priceStyle}>{seperator(Number(price))}원</span>
           <span>{title.slice(0, 10)}</span>
           <span className={nextText}>{title.slice(11)}</span>
         </div>

--- a/src/components/ShoppingSection/OnePlusDealCard.tsx
+++ b/src/components/ShoppingSection/OnePlusDealCard.tsx
@@ -1,39 +1,39 @@
 import { css } from '../../../styled-system/css';
 
 interface Props {
-  price: number;
+  price: string;
+  image: string;
+  title: string;
+  url: string;
 }
 
-const OnePlusDealCard = ({ price }: Props) => {
-  const title = '[설기획전] 오쏘몰 이뮨 2박스 포장 + 2일분 (쇼핑백 증정)';
-
+const OnePlusDealCard = ({ image, title, url, price }: Props) => {
   const handleSeperator = () => {
     return String(price).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
   };
 
   return (
-    <div className={container}>
-      <div className={imageBox}>
-        <div className={costBox}>
-          <div className={plus}>
-            <span>1+1</span>
+    <a href={url}>
+      <div className={container}>
+        <div className={imageBox}>
+          <div className={costBox}>
+            <div className={plus}>
+              <span>1+1</span>
+            </div>
+            <div className={discountBox}>
+              <span className={discount}>38%</span>
+            </div>
           </div>
-          <div className={discountBox}>
-            <span className={discount}>38%</span>
-          </div>
+          <div className={blur} />
+          <img src={image} className={image} />
         </div>
-        <div className={blur} />
-        <img
-          src="https://s.pstatic.net/shopping.phinf/20240130_18/f90772db-b620-4574-a3be-f9f2a4b8cf01.jpg?type=f320_230"
-          className={image}
-        />
+        <div className={textBox}>
+          <span className={priceStyle}>{handleSeperator()}원</span>
+          <span>{title.slice(0, 10)}</span>
+          <span className={nextText}>{title.slice(11)}</span>
+        </div>
       </div>
-      <div className={textBox}>
-        <span className={priceStyle}>{handleSeperator()}원</span>
-        <span>{title.slice(0, 10)}</span>
-        <span className={nextText}>{title.slice(11)}</span>
-      </div>
-    </div>
+    </a>
   );
 };
 
@@ -45,6 +45,13 @@ const container = css({
   width: '18rem',
   height: '18.9rem',
   cursor: 'pointer',
+  '& img': {
+    transition: 'transform 0.3s ease-in-out',
+  },
+  '&:hover img': {
+    transform: 'scale(1.1)',
+    transition: 'transform 0.3s ease-in-out',
+  },
 });
 
 const imageBox = css({
@@ -54,10 +61,6 @@ const imageBox = css({
   height: '11.5rem',
   overflow: 'hidden',
   borderRadius: '0.4rem',
-  transition: 'transform 0.2s',
-  '&:hover': {
-    transform: 'scale(1.05)',
-  },
 });
 
 const blur = css({
@@ -69,14 +72,6 @@ const blur = css({
   borderRadius: '0.4rem',
 });
 
-const image = css({
-  verticalAlign: 'top',
-  width: '100%',
-  height: '100%',
-  transform: 'scale(1.0)',
-  transition: 'transform 0.1s',
-});
-
 const textBox = css({
   paddingTop: '1rem',
   color: '#101010',
@@ -84,10 +79,6 @@ const textBox = css({
   fontWeight: '600',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
-  '&:hover': {
-    textDecoration: 'underline',
-    textUnderlineOffset: '0.25rem',
-  },
 });
 
 const priceStyle = css({

--- a/src/components/ShoppingSection/OnePlusDealHorizontalCard.tsx
+++ b/src/components/ShoppingSection/OnePlusDealHorizontalCard.tsx
@@ -3,46 +3,54 @@ import { css } from '../../../styled-system/css';
 interface Props {
   price: number;
   title: string;
+  image: string;
+  url: string;
 }
 
-const OnePlusDealHorizontalCard = ({ title, price }: Props) => {
+const OnePlusDealHorizontalCard = ({ image, url, title, price }: Props) => {
   const handleSeperator = () => {
     return String(price).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
   };
 
   return (
-    <div className={container}>
-      <div className={imageBox}>
-        <div className={costBox}>
-          <div className={plus}>
-            <span>1+1</span>
+    <a href={url}>
+      <div className={container}>
+        <div className={imageBox}>
+          <div className={costBox}>
+            <div className={plus}>
+              <span>1+1</span>
+            </div>
+            <div className={discountBox}>
+              <span className={discount}>38%</span>
+            </div>
           </div>
-          <div className={discountBox}>
-            <span className={discount}>38%</span>
-          </div>
+          <div className={blur} />
+          <img src={image} className={image} />
         </div>
-        <div className={blur} />
-        <img
-          src="https://s.pstatic.net/shopping.phinf/20240130_18/f90772db-b620-4574-a3be-f9f2a4b8cf01.jpg?type=f320_230"
-          className={image}
-        />
+        <div className={textBox}>
+          <p className={titleStyle}>{title.slice(0, 26)}...</p>
+          <p className={priceStyle}>{handleSeperator()}원</p>
+        </div>
       </div>
-      <div className={textBox}>
-        <p className={titleStyle}>{title}</p>
-        <p className={priceStyle}>{handleSeperator()}</p>
-      </div>
-    </div>
+    </a>
   );
 };
 
 export default OnePlusDealHorizontalCard;
 
 const container = css({
-  width: '22.9rem',
+  width: '22.8rem',
   height: '9.2rem',
   cursor: 'pointer',
   display: 'flex',
   flexDirection: 'row',
+  '& img': {
+    transition: 'transform 0.3s ease-in-out',
+  },
+  '&:hover img': {
+    transform: 'scale(1.1)',
+    transition: 'transform 0.3s ease-in-out',
+  },
 });
 
 const imageBox = css({
@@ -52,10 +60,6 @@ const imageBox = css({
   height: '9.2rem',
   overflow: 'hidden',
   borderRadius: '0.4rem',
-  transition: 'transform 0.2s',
-  '&:hover': {
-    transform: 'scale(1.05)',
-  },
 });
 
 const blur = css({
@@ -65,14 +69,6 @@ const blur = css({
   width: '16rem',
   height: '11.5rem',
   borderRadius: '0.4rem',
-});
-
-const image = css({
-  verticalAlign: 'top',
-  width: '100%',
-  height: '100%',
-  transform: 'scale(1.0)',
-  transition: 'transform 0.1s',
 });
 
 const costBox = css({
@@ -138,9 +134,17 @@ const textBox = css({
 const titleStyle = css({
   textOverflow: 'ellipsis',
   whiteSpace: 'wrap',
+  maxHeight: '3.8rem',
+  overflow: 'hidden',
+  lineHeight: '1.9rem',
+  WebkitLineClamp: 2,
+  fontSize: '1.3rem',
 });
 
 const priceStyle = css({
   marginTop: '0.4rem',
-  color: ' #F4361E',
+  color: '#F4361E',
+  fontWeight: '700',
+  fontSize: '1.35rem',
+  lineHeight: '1.9rem',
 });

--- a/src/components/ShoppingSection/OnePlusDealHorizontalCard.tsx
+++ b/src/components/ShoppingSection/OnePlusDealHorizontalCard.tsx
@@ -1,4 +1,5 @@
 import { css } from '../../../styled-system/css';
+import usePriceSeperator from '../../hooks/usePriceSeperator';
 
 interface Props {
   price: number;
@@ -8,9 +9,7 @@ interface Props {
 }
 
 const OnePlusDealHorizontalCard = ({ image, url, title, price }: Props) => {
-  const handleSeperator = () => {
-    return String(price).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-  };
+  const seperator = usePriceSeperator();
 
   return (
     <a href={url}>
@@ -29,7 +28,7 @@ const OnePlusDealHorizontalCard = ({ image, url, title, price }: Props) => {
         </div>
         <div className={textBox}>
           <p className={titleStyle}>{title.slice(0, 26)}...</p>
-          <p className={priceStyle}>{handleSeperator()}원</p>
+          <p className={priceStyle}>{seperator(price)}원</p>
         </div>
       </div>
     </a>

--- a/src/components/ShoppingSection/Shopping.tsx
+++ b/src/components/ShoppingSection/Shopping.tsx
@@ -1,0 +1,348 @@
+import { useEffect, useState } from 'react';
+import { css } from '../../../styled-system/css';
+import Section from '../base/Section';
+import Tabs from '../base/Tabs';
+import classNames from 'classnames';
+import PageButton from '../base/PageButton';
+import CategoryShopping from './CategoryShopping';
+import CategoryMens from './CategoryMens';
+import { useQuery } from 'react-query';
+import { getShoppingData } from '../../api/service';
+import CategoryOnePlusDeal from './CategoryOnePlusDeal';
+import SubCategories from './SubCategories';
+
+export type ShopItem = {
+  brand: string;
+  category1: string;
+  category2: string;
+  category3: string;
+  category4: string;
+  hprice: string;
+  image: string;
+  link: string;
+  lprice: string;
+  maker: string;
+  mallName: string;
+  productId: string;
+  productType: string;
+  title: string;
+};
+
+const categoryList = [
+  {
+    name: '쇼핑아이템',
+    totalPage: 5,
+  },
+  {
+    name: '맨즈아이템',
+    totalPage: 4,
+  },
+  {
+    name: '원쁠딜',
+    totalPage: 7,
+  },
+  {
+    name: '쇼핑라이브',
+    totalPage: 4,
+  },
+];
+
+const Shopping = () => {
+  const [currentCategory, setCurrentCategory] = useState<number>(0);
+  const [currentPage, setCurrentPage] = useState<number>(1);
+  const [shoppingData, setShoppingData] = useState<ShopItem[]>([]);
+
+  const { refetch } = useQuery<ShopItem[]>(
+    ['get-shoopping-list'],
+    () => getShoppingData({ category: currentCategory }),
+    {
+      onSuccess: (data) => {
+        if (data) {
+          setShoppingData(data.sort(() => Math.random() - 0.5));
+        }
+      },
+    },
+  );
+
+  useEffect(() => {
+    refetch();
+    setCurrentPage(1);
+  }, [currentCategory]);
+
+  const handlePressLeft = () => {
+    if (currentPage > 1) {
+      setCurrentPage(currentPage - 1);
+    } else {
+      const prevSectionTotalPage = categoryList[currentCategory].totalPage;
+
+      setCurrentPage(prevSectionTotalPage);
+    }
+  };
+
+  const handlePressRight = () => {
+    if (currentPage < categoryList[currentCategory].totalPage) {
+      setCurrentPage(currentPage + 1);
+    } else {
+      setCurrentPage(1);
+    }
+  };
+
+  return (
+    <Section>
+      <div className={container}>
+        <div className={tabRow}>
+          <Tabs
+            categories={['쇼핑', '맨즈', '원쁠딜', '쇼핑라이브']}
+            currentCategory={currentCategory}
+            onChangeCurrentCategory={(num: number) => setCurrentCategory(num)}
+          />
+        </div>
+        {[0, 1].includes(currentCategory) ? (
+          <div className={todayPick}>
+            <div className={todayPickContent}>
+              <span className={todayPickTitle}>오늘의 혜택</span>
+              <a className={todayPickMall}>
+                <span className={mallImageBox}>
+                  <img
+                    src="https://s.pstatic.net/shopping.phinf/20230523_26/0e20d198-b64e-450e-ae90-bdc4603e2188.jpg"
+                    className={mallImage}
+                  />
+                </span>
+                <span className={todayPickDesc}>
+                  디지털 라이프 BIG SALE~<em className={todayPickEmphasis}>최대 20만원쿠폰</em>
+                  +스마일페이 카드사할인
+                </span>
+              </a>
+            </div>
+            <div className={pagination}>
+              <div className={countContent}>
+                <span>{currentPage}</span>
+                <span className={total}>/{categoryList[currentCategory].totalPage}</span>
+              </div>
+              <button
+                type="button"
+                className={classNames(prevButton, todayPickButton)}
+                onClick={handlePressLeft}
+              >
+                <i className={arrowIcon(true)} />
+              </button>
+              <button
+                type="button"
+                className={classNames(nextButton, todayPickButton)}
+                onClick={handlePressRight}
+              >
+                <i className={arrowIcon(false)} />
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className={categoriesBox}>
+            <SubCategories
+              category={currentCategory}
+              currentPage={currentPage}
+              onSetPage={(num) => setCurrentPage(num)}
+            />
+          </div>
+        )}
+        {currentCategory === 0 && <CategoryShopping page={currentPage} data={shoppingData} />}
+        {currentCategory === 1 && <CategoryMens page={currentPage} data={shoppingData} />}
+        {currentCategory === 2 && <CategoryOnePlusDeal page={currentPage} data={shoppingData} />}
+        <div className={contentPaging}>
+          <PageButton
+            categoryName={categoryList[currentCategory].name}
+            currentPage={currentPage}
+            totalPage={categoryList[currentCategory].totalPage}
+            onPressLeft={handlePressLeft}
+            onPressRight={handlePressRight}
+          />
+        </div>
+      </div>
+    </Section>
+  );
+};
+
+export default Shopping;
+
+const container = css({
+  height: '100%',
+  position: 'relative',
+});
+
+const tabRow = css({
+  height: '5.8rem',
+  padding: '0 2rem',
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+});
+
+const todayPick = css({
+  display: 'flex',
+  margin: '0 2rem',
+});
+
+const todayPickContent = css({
+  backgroundColor: '#F5F7F8',
+  display: 'flex',
+  width: '66.8rem',
+  padding: '1.5rem 2rem 1.4rem',
+  borderRadius: '0.4rem',
+  boxSizing: 'border-box',
+  lineHeight: '2.1rem',
+  fontWeight: '700',
+  fontSize: '1.4rem',
+});
+
+const todayPickTitle = css({
+  flex: 'none',
+  position: 'relative',
+  paddingRight: '1.9rem',
+  fontWeight: '700',
+  '&::after': {
+    content: '""',
+    display: 'block',
+    position: 'absolute',
+    top: '0.8rem',
+    right: '0.8rem',
+    width: '0.3rem',
+    height: '0.3rem',
+    backgroundColor: '#D3D5D7',
+    borderRadius: '50%',
+  },
+});
+
+const todayPickMall = css({
+  flex: '1 1',
+  display: 'flex',
+  textDecoration: 'none',
+  fontSize: '1.4rem',
+  fontWeight: '600',
+  cursor: 'pointer',
+});
+
+const mallImageBox = css({
+  display: 'inline-block',
+  height: '1.3rem',
+  paddingTop: '0.4rem',
+  lineHeight: '1.3rem',
+  verticalAlign: 'top',
+});
+
+const mallImage = css({
+  border: 0,
+  height: '1.3rem',
+  overflowClipMargin: 'content-box',
+  overflow: 'clip',
+});
+
+const todayPickDesc = css({
+  marginLeft: '0.8rem',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  color: '#404040',
+  fontWeight: '600',
+});
+
+const todayPickEmphasis = css({
+  color: '#9858f5',
+  fontStyle: 'normal',
+});
+
+const pagination = css({
+  marginLeft: 'auto',
+  padding: '1rem 0',
+  display: 'block',
+  fontSize: '1.4rem',
+  lineHeight: '1.7rem',
+});
+
+const countContent = css({
+  color: '#606060',
+  display: 'inline-block',
+  margin: '0.6rem 0.9rem 0.8rem 0',
+  fontSize: '1.3rem',
+  lineHeight: '1.6rem',
+  fontWeight: '600',
+  verticalAlign: 'top',
+});
+
+const total = css({
+  color: 'rgba(113,113,113,.6)',
+});
+
+const todayPickButton = css({
+  width: '3rem',
+  height: '3rem',
+  position: 'relative',
+  display: 'inline-block',
+  border: '1px solid rgba(211,213,215,.8)',
+  verticalAlign: 'top',
+  cursor: 'pointer',
+});
+
+const prevButton = css({
+  borderRadius: '0.4rem 0 0 0.4rem',
+});
+
+const nextButton = css({
+  borderLeft: 0,
+  borderRadius: '0 0.4rem 0.4rem 0',
+});
+
+const arrowIcon = (isLeft: boolean) =>
+  css({
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    margin: 'auto',
+    width: '1rem',
+    height: '1.2rem',
+    display: 'inline-block',
+    '&::before': {
+      content: '""',
+      position: 'absolute',
+      top: '50%',
+      left: '50%',
+      width: '0.7rem',
+      height: '0.7rem',
+      transform: 'translate(-50%,-50%) rotate(45deg)',
+      borderLeft: isLeft ? '2px solid #80868c' : 'none',
+      borderBottom: isLeft ? '2px solid #80868c' : 'none',
+      borderTop: isLeft ? 'none' : '2px solid #80868c',
+      borderRight: isLeft ? 'none' : '2px solid #80868c',
+      marginLeft: '0.1rem',
+    },
+  });
+
+const contentPaging = css({
+  width: '100%',
+  position: 'absolute',
+  bottom: 0,
+  height: '5.7rem',
+  borderTop: '1px solid #EBEBEB',
+  paddingTop: '1rem',
+  paddingBottom: '1.1rem',
+  lineHeight: '3.4rem',
+  textAlign: 'center',
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  justifyContent: 'center',
+});
+
+const categoriesBox = css({
+  height: '5rem',
+  margin: '0 2rem',
+  padding: '0 2rem',
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  backgroundColor: '#F5F7F8',
+  borderRadius: '0.4rem',
+  fontSize: '1.5rem',
+});

--- a/src/components/ShoppingSection/Shopping.tsx
+++ b/src/components/ShoppingSection/Shopping.tsx
@@ -10,6 +10,7 @@ import { useQuery } from 'react-query';
 import { getShoppingData } from '../../api/service';
 import CategoryOnePlusDeal from './CategoryOnePlusDeal';
 import SubCategories from './SubCategories';
+import CategoryShoppingLive from './CategoryShoppingLive';
 
 export type ShopItem = {
   brand: string;
@@ -147,6 +148,7 @@ const Shopping = () => {
         {currentCategory === 0 && <CategoryShopping page={currentPage} data={shoppingData} />}
         {currentCategory === 1 && <CategoryMens page={currentPage} data={shoppingData} />}
         {currentCategory === 2 && <CategoryOnePlusDeal page={currentPage} data={shoppingData} />}
+        {currentCategory === 3 && <CategoryShoppingLive page={currentPage} />}
         <div className={contentPaging}>
           <PageButton
             categoryName={categoryList[currentCategory].name}

--- a/src/components/ShoppingSection/SubCategories.tsx
+++ b/src/components/ShoppingSection/SubCategories.tsx
@@ -1,0 +1,102 @@
+import classNames from 'classnames';
+import { css } from '../../../styled-system/css';
+
+interface Props {
+  category: number;
+  currentPage: number;
+  onSetPage: (num: number) => void;
+}
+
+const SubCategories = ({ category, currentPage, onSetPage }: Props) => {
+  const categories =
+    category === 2
+      ? ['HOT', '식품', '생활·육아', '패션소호', '디지털', '패션뷰티', '오픈예정']
+      : ['네쇼라Pick', '패션', '뷰티', '푸드', '라이프/테크', '키즈', '취미/여행/문화'];
+
+  return (
+    <div className={container}>
+      <div className={box}>
+        {categories.map((el, idx) => (
+          <div key={idx} className={classNames(box, pointer)} onClick={() => onSetPage(idx + 1)}>
+            {el === '오픈예정' ? (
+              <a className={classNames(text(idx + 1 === currentPage), alarmIcon)}>{el}</a>
+            ) : (
+              <a className={text(idx + 1 === currentPage)}>{el}</a>
+            )}
+            {idx < categories.length - 1 && <div className={wideDot} />}
+          </div>
+        ))}
+      </div>
+      <div className={box}>
+        <a
+          href={
+            category === 2
+              ? 'https://plusdeal.naver.com/?sort=1'
+              : 'https://shoppinglive.naver.com/home'
+          }
+          className={home}
+        >
+          {category === 2 && '원쁠딜 홈'}
+          {category === 3 && '쇼핑라이브 홈'}
+        </a>
+      </div>
+    </div>
+  );
+};
+
+export default SubCategories;
+
+const container = css({
+  width: '100%',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  fontSize: '1.45rem',
+});
+
+const box = css({
+  display: 'flex',
+  alignItems: 'center',
+});
+
+const pointer = css({
+  cursor: 'pointer',
+});
+
+const wideDot = css({
+  width: '0.3rem',
+  height: '0.3rem',
+  backgroundColor: '#d3d5d7',
+  borderRightRadius: '50%',
+  margin: '0 0.8rem',
+});
+
+const text = (isClicked: boolean) =>
+  css({
+    fontSize: '1.5rem',
+    color: isClicked ? '#101010' : 'rgba(16,16,16,.55)',
+    lineHeight: '2.1rem',
+    fontWeight: '800',
+  });
+
+const home = css({
+  fontSize: '1.45rem',
+  fontWeight: '800',
+  color: '#101010',
+});
+
+const alarmIcon = css({
+  '&::after': {
+    content: '""',
+    display: 'inline-block',
+    backgroundImage:
+      'url(https://spastatic.naver.com/v1/shopad/static/shopad-square-node/v2402021651/_next/static/media/sp_main.05384be4.png)',
+    backgroundSize: '15.9rem 13.7rem',
+    backgroundPosition: '-11.5rem -9.6rem',
+    backgroundRepeat: 'no-repeat',
+    width: '1.3rem',
+    height: '1.4rem',
+    margin: '0.3rem 0 0 0.3rem',
+    verticalAlign: 'top',
+  },
+});

--- a/src/components/ShoppingSection/ToBeOpenedCard.tsx
+++ b/src/components/ShoppingSection/ToBeOpenedCard.tsx
@@ -1,0 +1,189 @@
+import { css } from '../../../styled-system/css';
+
+interface Props {
+  image: string;
+  name: string;
+  when: string;
+}
+
+const ToBeOpenedCard = ({ image, name, when }: Props) => {
+  return (
+    <div className={container}>
+      <div className={imageBox}>
+        <span className={imageContent}>
+          <img src={image} style={{ width: '100%', height: '100%' }} />
+        </span>
+        <div className={infoBox}>
+          <div className={date}>{when}</div>
+          <div className={time}>17:00</div>
+        </div>
+      </div>
+      <div className={dataBox}>
+        <div className={tagBox}>
+          <span className={tagDouble}>1+@</span>
+          <span className={tagFreeShipping}>무료배송</span>
+        </div>
+        <div className={title}>{name}</div>
+        <div className={text}>알림받고 특가가격 확인</div>
+        <div className={btnBox}>
+          <button className={btnAlarm}>알림받기</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ToBeOpenedCard;
+
+const container = css({
+  display: 'flex',
+  alignItems: 'center',
+  width: '39.4rem',
+  height: '11rem',
+});
+
+const imageBox = css({
+  position: 'relative',
+  marginRight: '1.6rem',
+  borderRadius: '0.4rem',
+  display: 'block',
+});
+
+const dataBox = css({
+  paddingRight: '1rem',
+  minWidth: 0,
+  display: 'block',
+  width: '25rem',
+});
+
+const imageContent = css({
+  width: '11rem',
+  height: '11rem',
+  overflow: 'hidden',
+  position: 'relative',
+  display: 'block',
+  borderRadius: '0.4rem',
+  '&::after': {
+    content: '""',
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    border: '1px solid rgba(0,0,0,.06)',
+    borderRadius: 'inherit',
+    backgroundColor: 'rgba(0,0,0,.03)',
+    transform: 'translateZ(0)',
+    perspective: '0.1rem',
+  },
+});
+
+const infoBox = css({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderRadius: 'inherit',
+  backgroundImage: 'linear-gradient(0deg,rgba(0,0,0,.2),rgba(0,0,0,.2))',
+  color: 'white',
+});
+
+const date = css({
+  fontSize: '1.2rem',
+  lineHeight: '1.6rem',
+  fontWeight: '700',
+});
+
+const time = css({
+  marginTop: '0.3rem',
+  fontSize: '1.9rem',
+  lineHeight: '2.4rem',
+  fontWeight: '600',
+});
+
+const tagBox = css({
+  display: 'block',
+  textAlign: '-webkit-match-parent',
+  listStyle: 'none',
+});
+
+const title = css({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  marginTop: '0.8rem',
+  fontSize: '1.3rem',
+  lineHeight: '1.9em',
+  display: 'block',
+});
+
+const text = css({
+  color: '#F4361E',
+  marginTop: '0.1rem',
+  fontSize: '1.3rem',
+  lineHeight: '1.9rem',
+  display: 'block',
+});
+
+const btnBox = css({
+  position: 'relative',
+  display: 'inline-block',
+  marginTop: '0.5rem',
+  verticalAlign: 'top',
+});
+
+const tagDouble = css({
+  border: 'none',
+  background: 'linear-gradient(90deg,#b8c6d3,#9fabb8)',
+  lineHeight: '1.8rem',
+  fontWeight: '700',
+  color: 'white',
+  display: 'inline-block',
+  borderRadius: '0.2rem',
+  fontSize: '1rem',
+  padding: '0 0.4rem',
+});
+
+const tagFreeShipping = css({
+  marginLeft: '0.3rem',
+  backgroundColor: 'white',
+  display: 'inline-block',
+  padding: '0 0.4rem',
+  border: '1px solid rgba(162,174,187,.55)',
+  borderRadius: '0.2rem',
+  fontSize: '1rem',
+  lineHeight: '1.6rem',
+  verticalAlign: 'top',
+  color: '#8191a1',
+});
+
+const btnAlarm = css({
+  border: '1px solid #F4361E',
+  color: '#F4361E',
+  position: 'relative',
+  padding: '0 0.9rem',
+  borderRadius: '1.4rem',
+  fontSize: '1.1rem',
+  lineHeight: '2.2rem',
+  backgroundColor: 'transparent',
+  cursor: 'pointer',
+  '&::before': {
+    content: '""',
+    display: 'inline-block',
+    backgroundImage:
+      'url(https://spastatic.naver.com/v1/shopad/static/shopad-square-node/v2402021651/_next/static/media/sp_main.05384be4.png)',
+    backgroundSize: '15.9rem 13.7rem',
+    backgroundPosition: '-13.1rem -3.8rem',
+    backgroundRepeat: 'no-repeat',
+    width: '1.4rem',
+    height: '1.4rem',
+    margin: '0.4rem 0.5rem 0 0',
+    verticalAlign: 'top',
+    color: '#F4361E',
+  },
+});

--- a/src/components/ShoppingSection/constant/liveShoppingData.ts
+++ b/src/components/ShoppingSection/constant/liveShoppingData.ts
@@ -1,0 +1,108 @@
+export type CardData = {
+  text: string;
+  image: string;
+  poster?: string;
+  video: string;
+  watchers: number;
+  url: string;
+  product?: {
+    image: string;
+    name: string;
+    price: number;
+    discount: number;
+  };
+};
+
+export const cardData: CardData[] = [
+  {
+    text: '구찌 2024 가을 겨울 여성 패션쇼',
+    image:
+      'https://phinf.pstatic.net/dthumb/?src=https://g-selected.pstatic.net/MjAyNDAyMjNfMTQw/MDAxNzA4NjkyMDcyNjAy.OSyWookgtHVlVwqs4lHddXmhIzq3p8mg81HFFbwXSNEg.5sPz6H7hNKzfrabvZNl6yZ_egkWic_kr5R0_qWGQhgAg.JPEG/live_up1.jpg&service=shopad&type=f270_378',
+    url: 'https://view.shoppinglive.naver.com/replays/1251225?tr=mblim&fm=main&sn=shoppingblock',
+    poster:
+      'https://phinf.pstatic.net/dthumb/?src=https://g-selected.pstatic.net/MjAyNDAyMjNfMTQw/MDAxNzA4NjkyMDcyNjAy.OSyWookgtHVlVwqs4lHddXmhIzq3p8mg81HFFbwXSNEg.5sPz6H7hNKzfrabvZNl6yZ_egkWic_kr5R0_qWGQhgAg.JPEG/live_up1.jpg&service=shopad&type=f408_616',
+    video:
+      'https://a01-g-naver-vod.akamaized.net/selective/c/read/v2/VOD_ALPHA/selective_2024_02_24_32/cd8c645b-d25f-11ee-8130-a0369ffdb988.mp4?__gda__=1708734481_757d41f7f74c60b6c3897cc3232c4273',
+    watchers: 31899,
+  },
+  {
+    url: 'https://view.shoppinglive.naver.com/replays/1230082?tr=mblim&fm=main&sn=shoppingblock',
+    text: '[인텔 AI PC 위크] ASUS Zenbook ',
+    image:
+      'https://phinf.pstatic.net/dthumb/?src=https://g-selected.pstatic.net/MjAyNDAyMDhfMTc3/MDAxNzA3Mzc0MTM5NjYw.PfAzKpNU9WnkxrkWcgOoo5f8ounRBf22YM6pyi3aUH4g.Qh8X4_ldmCOSGPogxjQ11teT9PQfzN_3eFeAJfEdPGIg.PNG/live_up1.png&service=shopad&type=f270_378',
+    video:
+      'https://a01-g-naver-vod.akamaized.net/selective/c/read/v2/VOD_ALPHA/selective_2024_02_23_2/dd962674-d247-11ee-ac2a-e4434b2a1c7c.mp4?__gda__=1708732519_f9a846bf6955edb1ad77aed22d5483a1',
+    watchers: 474524,
+    product: {
+      image:
+        'https://phinf.pstatic.net/dthumb/?src=https://shop-phinf.pstatic.net/20240223_97/1708686131402fk8WC_JPEG/109822027133049735_1537813197.jpg&service=shopad&type=f110_110_q90',
+      name: 'ASUS 젠북 14인치 OLED 인텔 코어 울트라7 AI 대학생 노트북 사무용 인강용 가벼운',
+      price: 1499000,
+      discount: 16,
+    },
+  },
+  {
+    url: 'https://view.shoppinglive.naver.com/replays/1230078?tr=mblim&fm=main&sn=shoppingblock',
+    text: '[인텔 AI PC 위크] HP Omen Slim ',
+    image:
+      'https://phinf.pstatic.net/dthumb/?src=https://g-selected.pstatic.net/MjAyNDAyMDhfMTc2/MDAxNzA3Mzc0MTIwMjcw.piJxO85hNcEbnI86Kibeh8ulGmscIvqLgw3ps3lqYBMg.yy5Yg5YJtIwOvlkVcR_xb2qp09dh-RvubDKOBJcC8tYg.PNG/live_up1.png&service=shopad&type=f270_378',
+    video:
+      'https://a01-g-naver-vod.akamaized.net/selective/c/read/v2/VOD_ALPHA/selective_2024_02_22_26/b9c36a20-d17e-11ee-b73e-80615f0bcece.mp4?__gda__=1708727522_e0568544912014c0c66cf790eb542acc',
+    watchers: 471504,
+    product: {
+      image:
+        'https://phinf.pstatic.net/dthumb/?src=https://shop-phinf.pstatic.net/20240202_70/1706872485298a6AVB_JPEG/108008320128110668_978183718.jpg&service=shopad&type=f110_110_q90',
+      name: 'HP 노트북 스펙터 x360 16인치 대학생 인강용 사무용 업무용 16-aa0005TU',
+      price: 2399000,
+      discount: 14,
+    },
+  },
+  {
+    text: '[블루밍데이즈] The보장데이 에버콜라겐 초특가',
+    image:
+      'https://phinf.pstatic.net/dthumb/?src=https://g-selected.pstatic.net/MjAyNDAyMTZfMjQz/MDAxNzA4MDY3NTc1ODUz.Mfn5PRyxIyAzfykCtIg3iOkg9_sC6TUJrtjysntP4uAg.44mzUGNfZ50CWODlELaKR-9O-IGbio4CXP5D8KzRDqUg.JPEG/image.jpg&service=shopad&type=f270_378',
+    video:
+      'https://a01-g-naver-vod.akamaized.net/selective/c/read/v2/VOD_ALPHA/selective_2024_02_22_22/afe2689c-d17a-11ee-b5f5-a0369ffb3a60.mp4?__gda__=1708729322_5b94fd80ce3baa64772487b9deba98e9',
+    url: 'https://view.shoppinglive.naver.com/replays/1235174?tr=mblim&fm=main&sn=shoppingblock',
+    watchers: 444796,
+    product: {
+      image:
+        'https://phinf.pstatic.net/dthumb/?src=https://shop-phinf.pstatic.net/20230818_193/1692340764873fQn1y_JPEG/6054896737500007_1769648371.jpg&service=shopad&type=f110_110_q90',
+      name: '에버콜라겐 인앤업비오틴 업 42주 (6주x7개) / 기능성 저분자 콜라겐 펩타이드 뉴트리 콜라겐',
+      price: 291400,
+      discount: 38,
+    },
+  },
+  {
+    text: '[단군마켓]셀퓨전씨 최대 77% 할인+최대증정 LIVE',
+    image:
+      'https://phinf.pstatic.net/dthumb/?src=https://g-selected.pstatic.net/MjAyNDAyMjBfMTgw/MDAxNzA4MzkzNjg4MzQ4.jJZypYBG-ICBPHpxiIaJVJskbI9NgsZ0m0R3MuShUPAg.CLBWO4Fm6FbdHyp9Hgj0H6IZBtvVY_B3TXXhN4QEL-Ag.PNG/live_up1.png&service=shopad&type=f270_378',
+    video:
+      'https://a01-g-naver-vod.akamaized.net/selective/c/read/v2/VOD_ALPHA/selective_2024_02_22_41/a8d0b28e-d137-11ee-8130-a0369ffdb988.mp4?__gda__=1708732802_1ca49d785b299f0adf5536e5880c3b6a',
+    url: 'https://view.shoppinglive.naver.com/replays/1251870?tr=mblim&fm=main&sn=shoppingblock',
+    watchers: 287236,
+    product: {
+      image:
+        'https://phinf.pstatic.net/dthumb/?src=https://shop-phinf.pstatic.net/20240202_233/1706837267764lgEIf_JPEG/107973047486541484_191492830.jpg&service=shopad&type=f110_110_q90',
+      name: '셀퓨전씨 레이저 UV 썬 스크린 50ml+50ml / SPF50+ PA++++',
+      price: 34000,
+      discount: 59,
+    },
+  },
+  {
+    text: '[️신상위크️] 쥬크 S/S 신상 특가 LIVE',
+    image:
+      'https://phinf.pstatic.net/dthumb/?src=https://g-selected.pstatic.net/MjAyNDAyMDhfMjY1/MDAxNzA3MzU2NzY4Nzc3.hiuF5ttYIiIIRAm4B3VXKUDKFNDCh0uGhSgpPPxIxIcg.P8FvesFyBVaWXmwwulrdLjM2c4poQcklkReozrgxJuIg.JPEG/image.jpg&service=shopad&type=f270_378',
+    video:
+      'https://a01-g-naver-vod.akamaized.net/selective/c/read/v2/VOD_ALPHA/selective_2024_02_22_40/919c5e24-d165-11ee-ac2a-e4434b2a1c7c.mp4?__gda__=1708730956_db3cdaeecaec7db00418836e776d0f25',
+    url: 'https://view.shoppinglive.naver.com/replays/1228003?tr=mblim&fm=main&sn=shoppingblock',
+    watchers: 230110,
+    product: {
+      image:
+        'https://phinf.pstatic.net/dthumb/?src=https://shop-phinf.pstatic.net/20240216_236/17080488286371srO2_JPEG/35351512521473558_1675696129.jpg&service=shopad&type=f110_110_q90',
+      name: '[신상위크][ZOOC] 디테처블 니트 카라 패딩 점퍼_Z241PSG181',
+      price: 169000,
+      discount: 63,
+    },
+  },
+];

--- a/src/components/ShoppingSection/constant/upcomingData.ts
+++ b/src/components/ShoppingSection/constant/upcomingData.ts
@@ -1,0 +1,26 @@
+export const upcomingData = [
+  {
+    text: '제이숲 특가 라이브 역대급 쿠폰 특가 보장',
+    image:
+      'https://phinf.pstatic.net/dthumb/?src=https://g-selected.pstatic.net/MjAyNDAyMTlfMjEw/MDAxNzA4MzA5OTkzNDM4.g6XxM_p0coH6V7cyYne0We6XfwlXcFGlabAsHXtbLnAg.UIu6JsXItXsMW9BVs_ZJBrjw12PQvTLHG0ApN7s-2OYg.JPEG/image.jpg&service=shopad&type=f246_330',
+    url: 'https://shoppinglive.naver.com/livebridge/1244088?tr=mblim&fm=main&sn=shoppingblock',
+    brand: '제이숲N',
+    time: '2월 24일 11:00',
+  },
+  {
+    text: 'The보장데이 아메리칸투어리스터 라이브',
+    image:
+      'https://phinf.pstatic.net/dthumb/?src=https://g-selected.pstatic.net/MjAyNDAyMTNfMTk1/MDAxNzA3ODA0MjA3NTYx.mCrzoO-BUSMb05K8zZiWm6jE93H9vV6pfpFn0sB6XZIg.5qaZKeFeMfRD6O7u162Wb_31sG12ZMNcMS1rpZnCiNUg.JPEG/image.jpg&service=shopad&type=f246_330',
+    url: 'https://shoppinglive.naver.com/livebridge/1253954?tr=mblim&fm=main&sn=shoppingblock',
+    brand: '아메리칸 투어리스터',
+    time: '2월 24일 11:00',
+  },
+  {
+    text: '[탑텐 브랜드데이] 봄시즌 빅세일 ~67%OFF',
+    image:
+      'https://phinf.pstatic.net/dthumb/?src=https://g-selected.pstatic.net/MjAyNDAyMDZfMjk4/MDAxNzA3MTkxNTgwMjcz.Nc5Rxmz2phScp0Rl6yFGV1qzRGfLEqSIQH34nC1aQxQg.SVUZcRvp-lLKSLAfOIq6IvFT5_VuSfNiLJ_FOGqiUr0g.JPEG/image.jpg&service=shopad&type=f246_330',
+    url: 'https://shoppinglive.naver.com/livebridge/1249914?tr=mblim&fm=main&sn=shoppingblock',
+    brand: 'TOPTEN10',
+    time: '2월 24일 11:00',
+  },
+];

--- a/src/components/ShoppingSection/data.ts
+++ b/src/components/ShoppingSection/data.ts
@@ -1,0 +1,169 @@
+export type BrandItems = {
+  [key: string]: {
+    name: string;
+    image: string;
+    discount?: number;
+    price?: number;
+    url: string;
+  }[];
+};
+
+export const brandData: BrandItems = {
+  앙투어솔레: [
+    {
+      name: '프리미엄치즈',
+      image:
+        'https://s.pstatic.net/shopping.phinf/20240207_28/f2f7b08e-f124-4717-b0f3-abd57b59a808.jpg',
+      url: 'https://smartstore.naver.com/aislingkorea/products/6100556898?NaPm=ct%3Dlsvqs5yw%7Cci%3Df359063e816fa3fd598b4f879ada84992928ac74%7Ctr%3Dsbsb%7Csn%3D4389760%7Cic%3D%7Chk%3Da3cf2e3d1c45193bbfb50cd9d377033ffa09948a',
+    },
+    {
+      name: '소프트쿨러 백',
+      image:
+        'https://s.pstatic.net/shopping.phinf/20240202_25/359a7332-d140-4389-9ac6-8caac181d916.jpg',
+      url: 'https://smartstore.naver.com/aislingkorea/products/9805781174?NaPm=ct%3Dlsvqsqsw%7Cci%3D9e6debcadaa6dd2bd98912fa7a8443ce72975b19%7Ctr%3Dsbsb%7Csn%3D4389760%7Cic%3D%7Chk%3Dcc6f67315dc51b00978bb6bb1284759356de1aff',
+    },
+    {
+      name: '평점4.8점! 극찬 앙투어솔레 치즈!',
+      image:
+        'https://s.pstatic.net/shopping.phinf/20240207_4/8b119b73-eee2-4a02-b6d2-d05e684a63f3.jpg',
+      url: 'https://smartstore.naver.com/aislingkorea/products/6100556898?NaPm=ct%3Dlsvs0q4w%7Cci%3Dfa194dfac1da801080380674afbd228185fd612a%7Ctr%3Dsbsb%7Csn%3D4389760%7Cic%3D%7Chk%3D4e2bbc77f0084cb53a510dc631b568e71eb40d08',
+      price: 18900,
+    },
+  ],
+  도로시DOROCY: [
+    {
+      name: '랩 다이아몬드',
+      image:
+        'https://s.pstatic.net/shopping.phinf/20240219_8/40b2d7c5-c336-498e-a62b-e6be3a5f9225.jpg',
+      url: 'https://www.dorocy.co.kr/shop/shopbrand.html?xcode=066&type=P&ref=brandshop&da_ref=Yz05clZjOWw=&utm_source=naverbrand&utm_medium=PC&utm_campaign=01&NaPm=ct%3Dlsvquhaw%7Cci%3D722d886b8fad675911d5c4192ee7ba63f99241b2%7Ctr%3Dsbsb%7Csn%3D18417%7Cic%3D%7Chk%3D79a180ba22b39bb70cec56211edc679ccf9515e7',
+    },
+    {
+      name: '신상 초특가',
+      image:
+        'https://s.pstatic.net/shopping.phinf/20240219_9/60a32c61-e84a-4a3a-9211-9fa940eb94a9.jpg',
+      url: 'https://www.dorocy.co.kr/?ref=brandshop&da_ref=Yz1KWUx0VE4=&utm_source=naverbrand&utm_medium=PC&utm_campaign=02&NaPm=ct%3Dlsvqv1d4%7Cci%3D073ea2f57231befed09a085dc21d8dc3d62fc3bc%7Ctr%3Dsbsb%7Csn%3D18417%7Cic%3D%7Chk%3D327957ac0c94c405aec96b17e824bc1d5f3f4f53',
+      discount: 45,
+    },
+    {
+      name: '도로시 랩다이아몬드 신상10%쿠폰',
+      price: 1490000,
+      image:
+        'https://s.pstatic.net/shopping.phinf/20240219_10/1121bbd1-405c-448c-8543-dad4e6b79cff.jpg',
+      url: 'https://www.dorocy.co.kr/?ref=brandshop&da_ref=Yz1nY1RMcFM=&utm_source=naverbrand&utm_medium=PC&utm_campaign=03&NaPm=ct%3Dlsvqvt54%7Cci%3D740f15aa6ce9e18fd54328d17306a767347dfdb4%7Ctr%3Dsbsb%7Csn%3D18417%7Cic%3D%7Chk%3D15f73917bcc61267d2a2e1e98e1cd20eb3914478',
+    },
+  ],
+  '두닷 dodot': [
+    {
+      name: '오피스 의자',
+      image:
+        'https://s.pstatic.net/shopping.phinf/20240214_14/6980d22d-ab3e-4387-bc6a-dbafbcb8e4dd.jpg',
+      url: 'https://www.dodot.co.kr/play/salesView.php?sales_id=1484&NaPm=ct%3Dlsvr083c%7Cci%3D7243a8c7a3673d93ed119ddcef42b85c38b78a45%7Ctr%3Dsbsb%7Csn%3D272628%7Cic%3D%7Chk%3D6146de04361037d984e14421d638597ce76f749d',
+      discount: 21,
+    },
+    {
+      name: '집중력 상승',
+      image:
+        'https://s.pstatic.net/shopping.phinf/20240215_5/5b7de068-af4f-4f99-aab7-80eb1d392eff.jpg',
+      url: 'https://www.dodot.co.kr/play/salesView.php?sales_id=1484&NaPm=ct%3Dlsvr0niw%7Cci%3D1dd2beb5a3ce8ca7a7a015283f1a3b6ad9b76ff4%7Ctr%3Dsbsb%7Csn%3D272628%7Cic%3D%7Chk%3D53ada94a682bc049ba63a5e283f4918c434ba92f',
+      discount: 25,
+    },
+    {
+      name: '신학기 마지막 특가세일 +추가쿠폰',
+      price: 99000,
+      image:
+        'https://s.pstatic.net/shopping.phinf/20240214_5/5329fd1b-69a2-40e3-a6f6-d51327e67c6a.jpg',
+      url: 'https://www.dodot.co.kr/play/salesView.php?sales_id=1484&NaPm=ct%3Dlsvr161k%7Cci%3D70738fa4e46aa98d3257413d9773002991983518%7Ctr%3Dsbsb%7Csn%3D272628%7Cic%3D%7Chk%3D9e1dd142986188464d920b84fec62e4fecdd569a',
+    },
+  ],
+};
+
+export type ShopListData = {
+  name: string;
+  desc: string;
+  url: string;
+};
+
+export const shopList: ShopListData[] = [
+  {
+    name: '수아팜',
+    desc: '키즈 7부내의 전제품~50%',
+    url: 'https://suafam.com/?utm_source=naver_shoppingbox&utm_medium=mallnews&NaPm=ct%3Dlsvrkl48%7Cci%3D4a7b6311438227eedb0fa0c5ebb9c2b81e9d69b4%7Ctr%3Dsbsn%7Csn%3D3692208%7Cic%3D%7Chk%3Dc525f90f030354ca72dbd0b550bd3470bb87f916',
+  },
+  {
+    name: '린백의자',
+    desc: '접이식 강의실 의자 56%↓',
+    url: 'https://brand.naver.com/leanback/products/4546807190?NaPm=ct%3Dlsvrko7c%7Cci%3D769acde45a6ba5f772a8874ae6dc0ecb44623be2%7Ctr%3Dsbsn%7Csn%3D628980%7Cic%3D%7Chk%3D5c9738d9022239cb7feb8a748d1891f738482906',
+  },
+  {
+    name: '무아스',
+    desc: '가성비 인기LED시계51%↓',
+    url: 'https://brand.naver.com/mooas/products/477898500?NaPm=ct%3Dlsvrksu0%7Cci%3Db6255e6b7804619457e652464a8e571d93af71fb%7Ctr%3Dsbsn%7Csn%3D158690%7Cic%3D%7Chk%3D8dd9b75e2a3299a06111eb0af260b463bb275b5e',
+  },
+  {
+    name: '제이의옷장',
+    desc: '따뜻한 봄 최대80%할인',
+    url: 'https://j-closet.co.kr/?cafe_mkt=ue_shoppingnews&NaPm=ct%3Dlsvrkz08%7Cci%3D4c56caa10f065471e04623739c12549f9fa0cec0%7Ctr%3Dsbsn%7Csn%3D6944324%7Cic%3D%7Chk%3D4ac3fba97155d54fa1dd36bdeda3af3e2bbb4ba7',
+  },
+  {
+    name: '권코낄',
+    desc: '나만의 이니셜 휴대폰줄 세일',
+    url: 'https://adcr.shopping.naver.com/adclk.nhn?x=sJK3b6hjzDYaZG2XpWmH%2BP%2F%2F%2Fw%3D%3Dsmd8zBqMJQLjellaiFGSaxX%2F38UQVCT4dP8NnFC0WCzvt6yxuE90alRtFYpp%2BuYPqzM2CmU%2FJAmh2ByzkbR3Ae4XpYeG8am3dcLdd%2F2qMbldIXb7RKJ8Tin6t4n2p8uv0nSbK5M8SmMlr%2BfLn43c%2B15k8327OCVmuRtqDzcwx3sS4fN3qAH6F0Jd4iVd8KKfx%2BVX3TS9XZXSGPwk5AdOHm0gXo0THlckERN22IheXQhSMHnypgMYOj%2BppYy8krfLQlSa6ZoX%2F4DOrnkM8TJEQtf7NRxJhj7peoLXgd3%2FDPC2q6yd%2BHR4M%2F0IP%2BksWdu42NMaVndKEYoYwcIcLUKSz%2FQzP9p%2BbtSK4NQi%2B%2F%2BzI7eDgm6U5aYo7o%2BfUmrQ%2BSCm0c4nLN1EhiJrSViX8m6i7iI7lmVvWWetV%2Fz%2B2N2bD2diOM4VswGeHxDp116xw15KhZLtt9Ij03Otja8bBF76CIQt4MVJhkjWETR3WjivuvlU%3D',
+  },
+  {
+    name: '하이델로',
+    desc: '존재감듬뿍 금반지 39%',
+    url: 'https://adcr.shopping.naver.com/adclk.nhn?x=2jR6fSSmB7%2BFeVL9oxO%2Fjv%2F%2F%2Fw%3D%3Dsmd8zBqMJQLjellaiFGSaxX%2F38UQVCT4dP8NnFC0WCzvt6yxuE90alRtFYpp%2BuYPqzM2CmU%2FJAmh2ByzkbR3Ae4XpYeG8am3dcLdd%2F2qMbldIXb7RKJ8Tin6t4n2p8uv0nSbK5M8SmMlr%2BfLn43c%2B15k8327OCVmuRtqDzcwx3sSOB1KWyejAZmkM%2FYK%2BKDa9NLJhGVAehvKHGZ%2F7WuOlNQTHnYDCaDn88dKdQ2MXWzaMHnypgMYOj%2BppYy8krfLQlSa6ZoX%2F4DOrnkM8TJEQtf7NRxJhj7peoLXgd3%2FDPC2q6yd%2BHR4M%2F0IP%2BksWdu42NMaVndKEYoYwcIcLUKSz%2FSsPgNjsSUo0fn%2F%2BiMgsInngm6U5aYo7o%2BfUmrQ%2BSCm0FaFjVdu08ykb2oTM1tk21JhtSRrx619UHO10M4x5E%2BDAmxaonHKe2epebNjdJzLUf9Fa1m1D3mKJxYXd7TOebAt4MVJhkjWETR3WjivuvlU%3D',
+  },
+];
+
+type ToBeOpenedList = {
+  image: string;
+  name: string;
+  when: string;
+  benefit: string;
+};
+
+export const toBeOpenedList: ToBeOpenedList[] = [
+  {
+    image:
+      'https://s.pstatic.net/shopping.phinf/20240205_2/2b187de1-8c35-44cb-875e-1b1fce9601dd.jpg?type=f200',
+    name: '글래드 매직랩 미니(20cmx40m) 2개+컴팩트(30cmx12.3m) 2개',
+    when: '오늘오픈',
+    benefit: '1+@',
+  },
+  {
+    image:
+      'https://s.pstatic.net/shopping.phinf/20240205_16/2201eb82-2832-456b-8b8b-39057f1c6796.jpg?type=f200',
+    name: '먼지없는 방수 러그 2컬러+N페이 5%적립',
+    when: '오늘오픈',
+    benefit: '적립',
+  },
+  {
+    image:
+      'https://s.pstatic.net/shopping.phinf/20240205_3/04d7b2e9-abda-4086-8f15-a55ef3eae1fa.jpg?type=f200',
+    name: '디알고하이브리드노이즈캔슬링블루투스헤드폰ANC01+헤드셋거치대',
+    when: '오늘오픈',
+    benefit: '1+@',
+  },
+  {
+    image:
+      'https://s.pstatic.net/shopping.phinf/20240220_25/7b1a7b7b-f17c-419a-8613-677d3cda3829.jpg?type=f200',
+    name: '브라운 전기면도기 시리즈9 ProPLUS + 브라운룸슈즈',
+    when: '오늘오픈',
+    benefit: '1+@',
+  },
+  {
+    image:
+      'https://s.pstatic.net/shopping.phinf/20240205_24/c929e04f-8e0b-4886-8ddd-defa6d1846a1.jpg?type=f200',
+    name: '제대로 담은 국내산 100% 돼지포갈비 양념 돼지갈비 2팩+2팩',
+    when: '내일오픈',
+    benefit: '1+1',
+  },
+  {
+    image:
+      'https://s.pstatic.net/shopping.phinf/20240205_28/9dff8872-113b-4ced-9cc0-3280dff7a3c5.jpg?type=f200',
+    name: '1개+1개 바닥닿지 않는 집게 스텐조리도구 모음전 2개 세트',
+    when: '내일오픈',
+    benefit: '1+1',
+  },
+];

--- a/src/components/base/PageButton.tsx
+++ b/src/components/base/PageButton.tsx
@@ -22,6 +22,8 @@ const PageButton = ({
       return '#E538E2';
     } else if (categoryName === '경제 소식') {
       return '#008f76';
+    } else if (['쇼핑아이템', '맨즈아이템', '원쁠딜', '쇼핑라이브'].includes(categoryName)) {
+      return '#9858f5';
     }
 
     return '#3A67EA';

--- a/src/components/base/Tabs.tsx
+++ b/src/components/base/Tabs.tsx
@@ -16,7 +16,6 @@ const Tabs = ({ categories, currentCategory, onChangeCurrentCategory }: Props) =
           <div key={index} className={categoryBox}>
             <div>
               <a
-                href="#"
                 className={classnames(
                   tabText,
                   boldUnderline,
@@ -56,6 +55,7 @@ const tabText = css({
   fontSize: '1.68rem',
   fontWeight: '800',
   marginTop: '0.1rem',
+  cursor: 'pointer',
 });
 
 const lineDivider = css({

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -1,2 +1,4 @@
 export const VITE_APP_OPEN_WEATHER_API_KEY = import.meta.env.VITE_APP_OPEN_WEATHER_API_KEY;
 export const VITE_APP_ACCU_WEATHER_API_KEY = import.meta.env.VITE_APP_ACCU_WEATHER_API_KEY;
+export const VITE_APP_NAVER_CLIENT_ID = import.meta.env.VITE_APP_NAVER_CLIENT_ID;
+export const VITE_APP_NAVER_CLIENT_SECRET = import.meta.env.VITE_APP_NAVER_CLIENT_SECRET;

--- a/src/hooks/useAddHypen.ts
+++ b/src/hooks/useAddHypen.ts
@@ -1,0 +1,21 @@
+const useAddHypen = () => {
+  const convert = (phone: string) => {
+    const firstPart = phone.slice(0, 3);
+    let middlePart;
+    let lastPart = phone.slice(-4);
+
+    if (phone.length === 10) {
+      middlePart = phone.slice(3, 6);
+    } else if (phone.length === 11) {
+      middlePart = phone.slice(3, 7);
+    } else {
+      return phone;
+    }
+
+    return `${firstPart}-${middlePart}-${lastPart}`;
+  };
+
+  return convert;
+};
+
+export default useAddHypen;

--- a/src/hooks/usePriceSeperator.ts
+++ b/src/hooks/usePriceSeperator.ts
@@ -1,0 +1,9 @@
+const usePriceSeperator = () => {
+  const handleSeperator = (price: number) => {
+    return String(price).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  };
+
+  return handleSeperator;
+};
+
+export default usePriceSeperator;

--- a/src/hooks/useSmallWeatherIcon.ts
+++ b/src/hooks/useSmallWeatherIcon.ts
@@ -2,7 +2,6 @@ const useSmallWeatherIcon = () => {
   const getIcon = (weather: string, time: string) => {
     const hour = Number(time.split(':')[0]);
     const isNight = hour >= 20 || hour <= 5;
-    console.log(weather, time);
 
     if (weather.includes('맑음') || weather === '화창') {
       return isNight ? '-3.5rem -52.2rem' : '0 -52.2rem';

--- a/src/pages/Signup/SignupForm.tsx
+++ b/src/pages/Signup/SignupForm.tsx
@@ -33,6 +33,7 @@ import nameValidation from '../../hooks/nameValidation';
 import birthValidation from '../../hooks/birthValidation';
 import { css } from '../../../styled-system/css';
 import { useNavigate } from 'react-router-dom';
+import useAddHypen from '../../hooks/useAddHypen';
 
 const SignupForm = () => {
   const navigate = useNavigate();
@@ -41,6 +42,7 @@ const SignupForm = () => {
   const checkEmail = emailValidation();
   const checkName = nameValidation();
   const checkBirth = birthValidation();
+  const convertPhone = useAddHypen();
   const [focus, setFocus] = useState<number>(0);
   const [selectGender, setSelectGender] = useState<string>('');
   const [isChecked, setisChecked] = useState<boolean>(false);
@@ -69,21 +71,9 @@ const SignupForm = () => {
 
   const addHypenToNumber = () => {
     setInputs((inputs) => {
-      const firstPart = inputs.phone.slice(0, 3);
-      let middlePart;
-      let lastPart = inputs.phone.slice(-4);
-
-      if (inputs.phone.length === 10) {
-        middlePart = inputs.phone.slice(3, 6);
-      } else if (inputs.phone.length === 11) {
-        middlePart = inputs.phone.slice(3, 7);
-      } else {
-        return inputs;
-      }
-
       return {
         ...inputs,
-        phone: `${firstPart}-${middlePart}-${lastPart}`,
+        phone: convertPhone(inputs.phone),
       };
     });
   };

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,2 +1,3 @@
 /// <reference types="vite/client" />
 declare module '@styled-system/css';
+declare module 'dompurify';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,16 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  server: {
+    proxy: {
+      '/v1': {
+        target: 'https://openapi.naver.com',
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## 작업 내용
- 좌측 쇼핑 섹션 UI 및 로직 구현
- 네이버 쇼핑 검색 api를 활용하여 쇼핑, 맨즈, 원쁠딜 구현
- \<video> 태그를 사용하여 간단한 영상 출력

<img width="845" alt="스크린샷 2024-02-24 오전 1 52 28" src="https://github.com/chaeyun-sim/Naver-Clone/assets/111689342/27e16136-fedc-4e70-b41d-b126080d04c6">
<img width="851" alt="스크린샷 2024-02-24 오전 1 46 55" src="https://github.com/chaeyun-sim/Naver-Clone/assets/111689342/e9ec9915-898a-4881-9836-3c433ead221c">
<img width="845" alt="스크린샷 2024-02-24 오전 1 51 29" src="https://github.com/chaeyun-sim/Naver-Clone/assets/111689342/2ba575a8-c4c2-4e94-ba15-66b5a5f3b9c4">
<img width="839" alt="스크린샷 2024-02-24 오전 1 51 40" src="https://github.com/chaeyun-sim/Naver-Clone/assets/111689342/44a12d96-dd6a-475a-858d-db29e191a097">

Close #26 