### PR TITLE
[#28] 주식 섹션 구현

### DIFF
--- a/src/api/service.ts
+++ b/src/api/service.ts
@@ -4,6 +4,7 @@ import {
   VITE_APP_NAVER_CLIENT_ID,
   VITE_APP_NAVER_CLIENT_SECRET,
   VITE_APP_OPEN_WEATHER_API_KEY,
+  VITE_APP_STOCK_API_KEY,
 } from '../configs';
 
 type Name = {
@@ -195,7 +196,25 @@ export const getShoppingData = async ({ category }: { category: number }) => {
 
     return items.sort(() => Math.random() - 0.5);
   } catch (error) {
-    console.error(error);
-    return [];
+    console.log(`${error}`);
+  }
+};
+
+export const getStock = async () => {
+  try {
+    const params = {
+      serviceKey: VITE_APP_STOCK_API_KEY,
+      numOfRows: 30,
+      resultType: 'json',
+    };
+
+    const res = await axios.get(
+      'https://apis.data.go.kr/1160100/service/GetStockSecuritiesInfoService/getStockPriceInfo',
+      { params },
+    );
+
+    return res.data;
+  } catch (error) {
+    console.log(`${error}`);
   }
 };

--- a/src/assets/Spinner.tsx
+++ b/src/assets/Spinner.tsx
@@ -1,0 +1,158 @@
+const Spinner = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="80px"
+      height="80px"
+      viewBox="0 0 100 100"
+      preserveAspectRatio="xMidYMid"
+    >
+      <g transform="rotate(0 50 50)">
+        <rect x="47.5" y="24" rx="2.5" ry="6" width="5" height="12" fill="#02c75a">
+          <animate
+            attributeName="opacity"
+            values="1;0"
+            keyTimes="0;1"
+            dur="1s"
+            begin="-0.9166666666666666s"
+            repeatCount="indefinite"
+          ></animate>
+        </rect>
+      </g>
+      <g transform="rotate(30 50 50)">
+        <rect x="47.5" y="24" rx="2.5" ry="6" width="5" height="12" fill="#02c75a">
+          <animate
+            attributeName="opacity"
+            values="1;0"
+            keyTimes="0;1"
+            dur="1s"
+            begin="-0.8333333333333334s"
+            repeatCount="indefinite"
+          ></animate>
+        </rect>
+      </g>
+      <g transform="rotate(60 50 50)">
+        <rect x="47.5" y="24" rx="2.5" ry="6" width="5" height="12" fill="#02c75a">
+          <animate
+            attributeName="opacity"
+            values="1;0"
+            keyTimes="0;1"
+            dur="1s"
+            begin="-0.75s"
+            repeatCount="indefinite"
+          ></animate>
+        </rect>
+      </g>
+      <g transform="rotate(90 50 50)">
+        <rect x="47.5" y="24" rx="2.5" ry="6" width="5" height="12" fill="#02c75a">
+          <animate
+            attributeName="opacity"
+            values="1;0"
+            keyTimes="0;1"
+            dur="1s"
+            begin="-0.6666666666666666s"
+            repeatCount="indefinite"
+          ></animate>
+        </rect>
+      </g>
+      <g transform="rotate(120 50 50)">
+        <rect x="47.5" y="24" rx="2.5" ry="6" width="5" height="12" fill="#02c75a">
+          <animate
+            attributeName="opacity"
+            values="1;0"
+            keyTimes="0;1"
+            dur="1s"
+            begin="-0.5833333333333334s"
+            repeatCount="indefinite"
+          ></animate>
+        </rect>
+      </g>
+      <g transform="rotate(150 50 50)">
+        <rect x="47.5" y="24" rx="2.5" ry="6" width="5" height="12" fill="#02c75a">
+          <animate
+            attributeName="opacity"
+            values="1;0"
+            keyTimes="0;1"
+            dur="1s"
+            begin="-0.5s"
+            repeatCount="indefinite"
+          ></animate>
+        </rect>
+      </g>
+      <g transform="rotate(180 50 50)">
+        <rect x="47.5" y="24" rx="2.5" ry="6" width="5" height="12" fill="#02c75a">
+          <animate
+            attributeName="opacity"
+            values="1;0"
+            keyTimes="0;1"
+            dur="1s"
+            begin="-0.4166666666666667s"
+            repeatCount="indefinite"
+          ></animate>
+        </rect>
+      </g>
+      <g transform="rotate(210 50 50)">
+        <rect x="47.5" y="24" rx="2.5" ry="6" width="5" height="12" fill="#02c75a">
+          <animate
+            attributeName="opacity"
+            values="1;0"
+            keyTimes="0;1"
+            dur="1s"
+            begin="-0.3333333333333333s"
+            repeatCount="indefinite"
+          ></animate>
+        </rect>
+      </g>
+      <g transform="rotate(240 50 50)">
+        <rect x="47.5" y="24" rx="2.5" ry="6" width="5" height="12" fill="#02c75a">
+          <animate
+            attributeName="opacity"
+            values="1;0"
+            keyTimes="0;1"
+            dur="1s"
+            begin="-0.25s"
+            repeatCount="indefinite"
+          ></animate>
+        </rect>
+      </g>
+      <g transform="rotate(270 50 50)">
+        <rect x="47.5" y="24" rx="2.5" ry="6" width="5" height="12" fill="#02c75a">
+          <animate
+            attributeName="opacity"
+            values="1;0"
+            keyTimes="0;1"
+            dur="1s"
+            begin="-0.16666666666666666s"
+            repeatCount="indefinite"
+          ></animate>
+        </rect>
+      </g>
+      <g transform="rotate(300 50 50)">
+        <rect x="47.5" y="24" rx="2.5" ry="6" width="5" height="12" fill="#02c75a">
+          <animate
+            attributeName="opacity"
+            values="1;0"
+            keyTimes="0;1"
+            dur="1s"
+            begin="-0.08333333333333333s"
+            repeatCount="indefinite"
+          ></animate>
+        </rect>
+      </g>
+      <g transform="rotate(330 50 50)">
+        <rect x="47.5" y="24" rx="2.5" ry="6" width="5" height="12" fill="#02c75a">
+          <animate
+            attributeName="opacity"
+            values="1;0"
+            keyTimes="0;1"
+            dur="1s"
+            begin="0s"
+            repeatCount="indefinite"
+          ></animate>
+        </rect>
+      </g>
+    </svg>
+  );
+};
+
+export default Spinner;

--- a/src/components/Home/RightSection.tsx
+++ b/src/components/Home/RightSection.tsx
@@ -1,5 +1,6 @@
 import { css } from '../../../styled-system/css';
 import Login from '../LoginSection/Login';
+import Stock from '../RightSection/Stock/Stock';
 import Weather from '../RightSection/Weather/Weather';
 import Section from '../base/Section';
 
@@ -17,6 +18,7 @@ const RightSection = () => {
           </a>
         </Section>
         <Weather />
+        <Stock />
       </div>
     </div>
   );

--- a/src/components/Home/RightSection.tsx
+++ b/src/components/Home/RightSection.tsx
@@ -1,24 +1,26 @@
 import { css } from '../../../styled-system/css';
 import Login from '../LoginSection/Login';
+import Ad from '../RightSection/Ad/Ad';
 import Stock from '../RightSection/Stock/Stock';
 import Weather from '../RightSection/Weather/Weather';
-import Section from '../base/Section';
 
 const RightSection = () => {
   return (
     <div className={container}>
       <div className={loginWrapper}>
         <Login />
-        <Section style={{ height: '24rem', marginTop: '1.6rem' }}>
-          <a href="https://happybean.naver.com/fundings/detail/F1223">
-            <img
-              src="https://ssl.pstatic.net/melona/libs/1486/1486023/74f29aafb815fef79360_20240202152510385.jpg"
-              className={ad}
-            />
-          </a>
-        </Section>
+        <Ad
+          height="24rem"
+          url="https://happybean.naver.com/fundings/detail/F1223"
+          image="https://ssl.pstatic.net/melona/libs/1486/1486023/74f29aafb815fef79360_20240202152510385.jpg"
+        />
         <Weather />
         <Stock />
+        <Ad
+          height="8rem"
+          url="https://chzzk.naver.com/"
+          image="https://s.pstatic.net/static/www/mobile/edit/20240201_1095/upload_1706775713042cVCXR.png"
+        />
       </div>
     </div>
   );
@@ -33,11 +35,4 @@ const container = css({
 
 const loginWrapper = css({
   height: '16.4rem',
-});
-
-const ad = css({
-  width: '100%',
-  height: '100%',
-  overflow: 'hidden',
-  objectFit: 'fill',
 });

--- a/src/components/RightSection/Ad/Ad.tsx
+++ b/src/components/RightSection/Ad/Ad.tsx
@@ -1,0 +1,27 @@
+import Section from '../../base/Section';
+import { css } from '../../../../styled-system/css';
+
+interface Props {
+  height: string;
+  url: string;
+  image: string;
+}
+
+const Ad = ({ height, url, image }: Props) => {
+  return (
+    <Section height={height} style={{ marginTop: '1.6rem' }}>
+      <a href={url}>
+        <img src={image} className={ad} />
+      </a>
+    </Section>
+  );
+};
+
+export default Ad;
+
+const ad = css({
+  width: '100%',
+  height: '100%',
+  overflow: 'hidden',
+  objectFit: 'fill',
+});

--- a/src/components/RightSection/Stock/MostSearched.tsx
+++ b/src/components/RightSection/Stock/MostSearched.tsx
@@ -1,0 +1,111 @@
+import { css } from '../../../../styled-system/css';
+import Spinner from '../../../assets/Spinner';
+import usePriceSeperator from '../../../hooks/usePriceSeperator';
+import { StockType, infoBox, stockName, typeDown } from './Stock';
+
+interface Props {
+  isLoading: boolean;
+  data: StockType[];
+}
+
+const MostSearched = ({ isLoading, data }: Props) => {
+  const convertNumber = usePriceSeperator();
+
+  return (
+    <div className={infoBox}>
+      <ul style={{ listStyle: 'none' }}>
+        {data.slice(0, 3).map((item, index) => (
+          <li key={index} className={stockItem}>
+            <a className={stockLink}>
+              <span className={stockName}>{item.itmsNm}</span>
+              <span className={stockSmallPrice}>
+                {Number(item.fltRt) < 0 ? (
+                  <i className={typeDown(false)} />
+                ) : (
+                  <i className={typeUp(false)} />
+                )}
+                {convertNumber(Number(item.clpr))}
+              </span>
+            </a>
+          </li>
+        ))}
+        {data.length > 0 && (
+          <li className={stockItem}>
+            <a className={typeMore} href="https://finance.naver.com/sise/lastsearch2.naver">
+              인기종목 더보기
+            </a>
+          </li>
+        )}
+        {(isLoading || !data.length) && (
+          <li
+            style={{
+              height: '14.4rem',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Spinner />
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+};
+
+export default MostSearched;
+
+const stockItem = css({
+  height: '3.6rem',
+  borderBottom: '1px solid #EBEBEB',
+});
+
+const stockLink = css({
+  padding: '0.6rem 0 0.9rem',
+  display: 'flex',
+  justifyContent: 'space-between',
+  lineHeight: '2.1rem',
+  cursor: 'pointer',
+});
+
+const stockSmallPrice = css({
+  fontSize: '1.4rem',
+  lineHeight: '2.1rem',
+});
+
+const typeUp = (isDisplay: boolean) =>
+  css({
+    backgroundImage: 'url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)',
+    backgroundSize: '44.4rem 43.4rem',
+    backgroundPosition: '-14.3rem -27.2rem',
+    backgroundRepeat: 'no-repeat',
+    width: '0.9rem',
+    height: '0.6rem',
+    margin: isDisplay ? '0.8rem 0.4rem 0 0' : '0.8rem 0.4rem 0.1rem 0',
+    backgroundColor: 'rgba(0,0,0,0)',
+    display: 'inline-block',
+  });
+
+const typeMore = css({
+  color: '#606060',
+  position: 'relative',
+  display: 'flex',
+  justifyContent: 'space-between',
+  padding: '0.8rem 0 0.9rem',
+  lineHeight: '2.1rem',
+  fontSize: '1.4rem',
+  cursor: 'pointer',
+  '&::after': {
+    content: '""',
+    display: 'block',
+    position: 'absolute',
+    top: '1.3rem',
+    right: 0,
+    backgroundImage: 'url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)',
+    backgroundSize: '44.4rem 43.4rem',
+    backgroundPosition: '-43.2rem -28.5rem',
+    backgroundRepeat: 'no-repeat',
+    width: '1rem',
+    height: '1.2rem',
+  },
+});

--- a/src/components/RightSection/Stock/Nasdaq.tsx
+++ b/src/components/RightSection/Stock/Nasdaq.tsx
@@ -1,0 +1,80 @@
+import { css } from '../../../../styled-system/css';
+import { infoBox, stockName, typeDown } from './Stock';
+
+const Nasdaq = () => {
+  return (
+    <div className={infoBox}>
+      <div className={rolling}>
+        <a
+          href="https://finance.naver.com/world/sise.nhn?symbol=DJI@DJI"
+          target="_blank"
+          rel="noreferrer"
+          style={{ textDecoration: 'none' }}
+        >
+          <div>
+            <div className={stockName}>나스닥</div>
+            <div className={stockPrice}>15,996.82</div>
+            <div className={statusIcon}>
+              <i className={typeDown(true)}></i>
+              44.80
+              <span className={rate(-0.28 > 0)}>-0.28%</span>
+            </div>
+            <div className={stockGraph}>
+              <img
+                src="https://ssl.pstatic.net/imgfinance/chart/mobile/world/mini/.IXIC_naverpc_l.png"
+                width={180}
+                height={72}
+              />
+            </div>
+          </div>
+        </a>
+      </div>
+    </div>
+  );
+};
+
+export default Nasdaq;
+
+const rolling = css({
+  width: '100%',
+  flexShrink: 0,
+  cursor: 'pointer',
+});
+
+const stockPrice = css({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  marginTop: '0.3rem',
+  fontSize: '2.4rem',
+  lineHeight: '3rem',
+  letterSpacing: '-.7px',
+});
+
+const statusIcon = css({
+  color: '#2196f3',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  position: 'relative',
+  marginTop: '0.2rem',
+  fontSize: '1.4rem',
+  lineHeight: '1.7rem',
+  display: 'inline-block',
+});
+
+const rate = (isUp: boolean) =>
+  css({
+    paddingLeft: '0.6rem',
+    color: !isUp ? '#2196f3' : '#F44336',
+    whiteSpace: 'nowrap',
+    fontSize: '1.4rem',
+    lineHeight: '1.7rem',
+  });
+
+const stockGraph = css({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  marginTop: '0.6rem',
+});

--- a/src/components/RightSection/Stock/Stock.tsx
+++ b/src/components/RightSection/Stock/Stock.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+import { css } from '../../../../styled-system/css';
+import { useQuery } from 'react-query';
+import { getStock } from '../../../api/service';
+import StockHeader from './StockHeader';
+import Nasdaq from './Nasdaq';
+import MostSearched from './MostSearched';
+
+export type StockType = {
+  basDt: string; // 기준일자
+  clpr: string; // 종가
+  fltRt: string; // 등락률
+  hipr: string; // 고가
+  isinCd: string; // ISIN 코드
+  itmsNm: string; // 종목명
+  lopr: string; // 저가
+  lstgStCnt: string; // 상장주식수
+  mkp: string; // 시가
+  mrktCtg: string; // 시장구분
+  mrktTotAmt: string; // 시가총액
+  srtnCd: string; // 단축코드
+  trPrc: string; // 거래대금
+  trqu: string; // 거래량
+  vs: string; // 대비
+};
+
+const Stock = () => {
+  const [stockData, setStockData] = useState<StockType[]>([]);
+
+  const { isLoading, refetch } = useQuery(['get-stock-data'], () => getStock(), {
+    onSuccess: (data) => {
+      if (data.response.body.items.item) {
+        setStockData(
+          data.response.body.items.item.sort(
+            (a: StockType, b: StockType) => Number(b.clpr) - Number(a.clpr),
+          ),
+        );
+        console.log(stockData);
+      }
+
+      if (!data && !isLoading) {
+        refetch();
+      }
+    },
+  });
+
+  return (
+    <div className={container}>
+      <div className={dailyBoard}>
+        <StockHeader />
+        <div className={infoGroup}>
+          <Nasdaq />
+          <MostSearched isLoading={isLoading} data={stockData} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Stock;
+
+const container = css({
+  width: '100%',
+  height: '23.6rem',
+  marginTop: '1.6rem',
+  backgroundColor: 'white',
+  position: 'relative',
+  borderRadius: '0.8rem',
+  boxShadow: '0 0 0 1px #e3e5e8, 0 1px 2px 0 rgba(0,0,0,.04)',
+  boxSizing: 'border-box',
+  display: 'block',
+  '&::after': {
+    content: '""',
+    display: 'table',
+    tableLayout: 'fixed',
+    clear: 'both',
+  },
+});
+
+const dailyBoard = css({
+  padding: '0 1.8rem',
+});
+
+const infoGroup = css({
+  borderTop: '1px solid #EBEBEB',
+  position: 'relative',
+  display: 'flex',
+});
+
+export const infoBox = css({
+  margin: '0.9rem 0 1.4rem',
+  position: 'relative',
+  flex: 1,
+  display: 'block',
+  height: '16rem',
+  width: '18rem',
+  '&:nth-child(2)': {
+    marginLeft: '2.5rem',
+  },
+});
+
+export const stockName = css({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  fontSize: '1.5rem',
+  lineHeight: '1.9rem',
+});
+
+export const typeDown = (isDisplay: boolean) =>
+  css({
+    backgroundImage: 'url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)',
+    backgroundSize: '44.4rem 43.4rem',
+    backgroundPosition: '-13.3rem -27.2rem',
+    backgroundRepeat: 'no-repeat',
+    width: '0.9rem',
+    height: '0.6rem',
+    margin: isDisplay ? '0.8rem 0.4rem 0.1rem 0' : '0.8rem 0.4rem 0.1rem 0',
+    backgroundColor: 'rgba(0,0,0,0)',
+    display: 'inline-block',
+  });

--- a/src/components/RightSection/Stock/StockHeader.tsx
+++ b/src/components/RightSection/Stock/StockHeader.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useState } from 'react';
+import { css } from '../../../../styled-system/css';
+
+const StockHeader = () => {
+  const [stockHelp, setStockHelp] = useState<boolean>(false);
+  const [isHovering, setIsHovering] = useState<boolean>(false);
+  const [currentTime, setCurrentTime] = useState<string>('');
+
+  const getCurrentTime = () => {
+    const curr = new Date();
+    const utc = curr.getTime() + curr.getTimezoneOffset() * 60 * 1000;
+    const KR_TIME_DIFF = 9 * 60 * 60 * 1000;
+    const kr_curr = new Date(utc + KR_TIME_DIFF);
+
+    const date = kr_curr.toISOString().split('T')[0].split('-').slice(1, 3).join('.') + '.';
+    const time = kr_curr.toString().split(' ')[4].split(':').slice(0, 2).join(':');
+
+    return `${date} ${time}`;
+  };
+
+  useEffect(() => {
+    setCurrentTime(getCurrentTime());
+  }, []);
+
+  return (
+    <div className={headerGroup}>
+      <a href="https://finance.naver.com/" target="_blank" rel="noreferrer" className={headerTitle}>
+        증시
+      </a>
+      <button
+        type="button"
+        className={btnInfo(stockHelp)}
+        aria-expanded="false"
+        aria-hidden="false"
+        onClick={() => setStockHelp(!stockHelp)}
+      >
+        <span className={blind}>정보 더보기</span>
+      </button>
+      {stockHelp && (
+        <p className={layerInfo} aria-hidden="false">
+          로그인 시 관심 종목의 주가를 확인할 수 있습니다.
+          <br />
+          로그아웃 시 인기 검색 종목이 제공됩니다.
+          <button className={btnClose} onClick={() => setStockHelp(false)}>
+            <span className={blind}>닫기</span>
+          </button>
+        </p>
+      )}
+      <div className={headerAside}>
+        {currentTime}
+        <button
+          className={btnRefresh(isHovering)}
+          onClick={() => setCurrentTime(getCurrentTime())}
+          onMouseOver={() => setIsHovering(true)}
+          onMouseOut={() => setIsHovering(false)}
+        >
+          <span className={blind}>새로고침</span>
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default StockHeader;
+
+const headerGroup = css({
+  position: 'relative',
+  display: 'flex',
+  padding: '0.6rem 0',
+  lineHeight: '4rem',
+});
+
+const headerTitle = css({
+  color: '#080808',
+  display: 'inline-block',
+  paddingRight: '0.7rem',
+  fontSize: '1.5rem',
+  fontWeight: '800',
+  verticalAlign: 'top',
+});
+
+const btnInfo = (isClicked: boolean) =>
+  css({
+    width: '2rem',
+    height: '2rem',
+    position: 'relative',
+    margin: '1rem 0 0 -0.4rem',
+    cursor: 'pointer',
+    display: 'block',
+    '&::before': {
+      content: '""',
+      display: 'block',
+      position: 'relative',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      backgroundImage: 'url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)',
+      backgroundSize: '44.4rem 43.4rem',
+      backgroundPosition: '-41.6rem -7.2rem',
+      backgroundRepeat: 'no-repeat',
+      width: '1.4rem',
+      height: '1.4rem',
+      margin: 'auto',
+    },
+    ...(isClicked && {
+      '&::after': {
+        content: '""',
+        display: 'block',
+        position: 'absolute',
+        top: '1.89rem',
+        bottom: '-1rem',
+        left: '50%',
+        backgroundImage: 'url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)',
+        backgroundSize: '44.4rem 43.4rem',
+        backgroundPosition: '-26.6rem -25.4rem',
+        backgroundRepeat: 'no-repeat',
+        width: '2rem',
+        height: '1.1em',
+        transform: 'translateX(-50%)',
+        zIndex: 2,
+      },
+    }),
+  });
+
+const blind = css({
+  position: 'absolute',
+  clip: 'rect(0 0 0 0)',
+  width: '0.1rem',
+  height: '0.1rem',
+  margin: '-0.1rem',
+  overflow: 'hidden',
+});
+
+const layerInfo = css({
+  position: 'absolute',
+  top: '4.5rem',
+  left: '-0.2rem',
+  width: '31.2rem',
+  border: '1px solid #D3D5D7',
+  backgroundColor: 'white',
+  color: '#404040',
+  padding: '1.4rem 2rem',
+  boxShadow: '0 3px 6px 0 rgba(0,0,0,.06)',
+  boxSizing: 'border-box',
+  fontSize: '1.3rem',
+  lineHeight: '2rem',
+  wordBreak: 'keep-all',
+  fontWeight: '500',
+  zIndex: 1,
+});
+
+const headerAside = css({
+  color: '#606060',
+  flex: 'none',
+  marginLeft: 'auto',
+  fontSize: '1.3rem',
+});
+
+const btnClose = css({
+  position: 'absolute',
+  top: 0,
+  right: 0,
+  padding: '1.6rem',
+  '&::before': {
+    content: '""',
+    display: 'block',
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundImage: 'url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)',
+    backgroundSize: '44.4rem 43.4rem',
+    backgroundPosition: '-43.2rem -32.1rem',
+    backgroundRepeat: 'no-repeat',
+    width: '1rem',
+    height: '1rem',
+    margin: 'auto',
+    cursor: 'pointer',
+  },
+});
+
+const btnRefresh = (isHovering: boolean) =>
+  css({
+    display: 'inline-block',
+    padding: '1.2rem 0 1.2rem 0.5rem',
+    verticalAlign: 'top',
+    cursor: 'pointer',
+    backgroundColor: 'white',
+    '&::before': {
+      content: '""',
+      display: 'block',
+      backgroundImage: 'url(https://pm.pstatic.net/resources/asset/sp_main.ae81c9d5.png)',
+      backgroundSize: '44.4rem 43.4rem',
+      backgroundPosition: isHovering ? '-32.7rem -38.4rem' : '-34.4rem -38.4rem',
+      backgroundRepeat: 'no-repeat',
+      width: '1.6rem',
+      height: '1.6rem',
+    },
+  });

--- a/src/components/base/Section.tsx
+++ b/src/components/base/Section.tsx
@@ -4,11 +4,12 @@ import { css } from '../../../styled-system/css';
 interface Props {
   children: React.ReactNode;
   style?: React.CSSProperties;
+  height?: string;
 }
 
-const Section = ({ children, style }: Props) => {
+const Section = ({ children, style, height }: Props) => {
   const section = css({
-    height: '100%',
+    height: height || '100%',
     width: '100%',
     border: '0.1px solid #EBEBEB',
     borderRadius: '0.8rem',

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -2,3 +2,4 @@ export const VITE_APP_OPEN_WEATHER_API_KEY = import.meta.env.VITE_APP_OPEN_WEATH
 export const VITE_APP_ACCU_WEATHER_API_KEY = import.meta.env.VITE_APP_ACCU_WEATHER_API_KEY;
 export const VITE_APP_NAVER_CLIENT_ID = import.meta.env.VITE_APP_NAVER_CLIENT_ID;
 export const VITE_APP_NAVER_CLIENT_SECRET = import.meta.env.VITE_APP_NAVER_CLIENT_SECRET;
+export const VITE_APP_STOCK_API_KEY = import.meta.env.VITE_APP_STOCK_API_KEY;


### PR DESCRIPTION
## 작업 내용
- 주식 섹션 UI 구현
- 공공데이터 '금융위원회_주식시세정보' API 활용
  - 국내 주식 관련 API는 운영체제 등 이슈에 의해 사용하지 못하게 됨.
- 나스닥 관련 API를 찾지 못해 하드 코딩으로 작성
- 최고/최저 등락율 기준으로 리스트 작성 및 표시
- 로딩 이미지 생성 및 구현

<img width="308" alt="스크린샷 2024-02-24 오후 11 09 24" src="https://github.com/chaeyun-sim/Naver-Clone/assets/111689342/1595d32b-005c-428f-9c39-a653b3f931b3">
<img width="312" alt="스크린샷 2024-02-24 오후 11 09 19" src="https://github.com/chaeyun-sim/Naver-Clone/assets/111689342/ec3d6526-9abf-4cf0-a29b-f3d8ebed650d">

<br />

Close #28 